### PR TITLE
Secure user APIs and kiosk clock actions

### DIFF
--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -2,11 +2,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserById, deleteUser, updateUser, getAllUsers } from "@/utils/dynamo";
 import {User} from "@/types/user";
+import { requireAdminApi } from "@/utils/apiAuth";
 
 export async function GET(
     req: NextRequest,
     context: { params: Promise<{ id: string }> }
 ) {
+    const unauthorized = await requireAdminApi("read");
+    if (unauthorized) return unauthorized;
     const { id } = await context.params;
     const user = await getUserById(id);
     if (!user) {
@@ -16,19 +19,20 @@ export async function GET(
 }
 
 export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+    const unauthorized = await requireAdminApi("edit");
+    if (unauthorized) return unauthorized;
     const { id } = await context.params;
     const body = await req.json();
 
     try {
-        const allowedUpdates = {
-            firstName: body.firstName,
-            lastName: body.lastName,
-            pin: body.pin,
-            email: body.email,
-            adminLevel: body.adminLevel,
-            roles: Array.isArray(body.roles) ? body.roles : [],        // roles as string[]
-            learners: Array.isArray(body.learners) ? body.learners : [], // learners as User[]
-        };
+        const allowedUpdates: Partial<User> = {};
+        if ("firstName" in body) allowedUpdates.firstName = body.firstName;
+        if ("lastName" in body) allowedUpdates.lastName = body.lastName;
+        if ("pin" in body) allowedUpdates.pin = body.pin;
+        if ("email" in body) allowedUpdates.email = body.email;
+        if ("adminLevel" in body) allowedUpdates.adminLevel = body.adminLevel;
+        if ("roles" in body && Array.isArray(body.roles)) allowedUpdates.roles = body.roles;
+        if ("learners" in body && Array.isArray(body.learners)) allowedUpdates.learners = body.learners;
 
         const updatedUser: User | null = await updateUser(id, allowedUpdates);
 
@@ -40,6 +44,8 @@ export async function PATCH(req: NextRequest, context: { params: Promise<{ id: s
 }
 
 export async function DELETE(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+    const unauthorized = await requireAdminApi("edit");
+    if (unauthorized) return unauthorized;
     const { id } = await context.params;
 
     try {

--- a/src/app/api/users/[id]/status/route.ts
+++ b/src/app/api/users/[id]/status/route.ts
@@ -1,26 +1,51 @@
 import { NextRequest, NextResponse } from "next/server";
-import { updateUserStatus, logTimeClock } from "@/utils/dynamo";
-
+import {
+    getUserById,
+    getUserByPin,
+    updateUserStatus,
+    logTimeClock,
+} from "@/utils/dynamo";
 
 export async function PATCH(
     req: NextRequest,
     context: { params: Promise<{ id: string }> }
 ) {
     const { id } = await context.params;
-    const body = await req.json();
-    const { status, userType, clockedById } = body; // userType optional; fallback if you store it elsewhere
+    const { status, pin } = await req.json();
 
     if (!["In", "Out"].includes(status)) {
         return NextResponse.json({ error: "Invalid status" }, { status: 400 });
     }
+    if (typeof pin !== "string" || !/^\d{4}$/.test(pin)) {
+        return NextResponse.json({ error: "A valid PIN is required" }, { status: 401 });
+    }
 
     try {
-        // 1️⃣ Update user state in your app
+        const [actor, target] = await Promise.all([getUserByPin(pin), getUserById(id)]);
+        if (!actor || !target) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const canClockSelf = actor.userId === target.userId &&
+            actor.roles.some((role) => ["staff", "volunteer"].includes(role.toLowerCase()));
+        const canClockLearner = actor.roles.includes("guardian") &&
+            actor.learners?.some((learner) => learner.userId === target.userId);
+        if (!canClockSelf && !canClockLearner) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+
+        const userType = target.roles.find((role) =>
+            ["staff", "volunteer", "learner"].includes(role.toLowerCase())
+        )?.toLowerCase();
+        if (!userType) {
+            return NextResponse.json(
+                { error: "User cannot use the time clock" },
+                { status: 400 }
+            );
+        }
+
         const updatedUser = await updateUserStatus(id, status);
-
-        // 2️⃣ Log to DynamoDB
-        await logTimeClock(id, userType || "Learner", status, clockedById);
-
+        await logTimeClock(id, userType, status, actor.userId);
         return NextResponse.json(updatedUser);
     } catch (err) {
         console.error(err);

--- a/src/app/api/users/by-email/route.ts
+++ b/src/app/api/users/by-email/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserByEmail } from "@/utils/dynamo";
+import { requireAdminApi } from "@/utils/apiAuth";
 
 export async function GET(req: NextRequest) {
+    const unauthorized = await requireAdminApi("read");
+    if (unauthorized) return unauthorized;
     const email = req.nextUrl.searchParams.get("email");
     if (!email) return NextResponse.json({ error: "Email is required" }, { status: 400 });
 

--- a/src/app/api/users/by-pin/route.ts
+++ b/src/app/api/users/by-pin/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserByPin } from "@/utils/dynamo";
+import { KioskUser } from "@/types/user";
 
 export async function GET(req: NextRequest) {
     const pin = req.nextUrl.searchParams.get("pin");
@@ -8,5 +9,21 @@ export async function GET(req: NextRequest) {
     const user = await getUserByPin(pin);
     if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
 
-    return NextResponse.json(user);
+    const kioskUser: KioskUser = {
+        userId: user.userId,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        roles: user.roles,
+        status: user.status,
+        lastClockTransaction: user.lastClockTransaction,
+        ...(user.roles.includes("guardian") ? {
+            learners: user.learners?.map((learner) => ({
+                userId: learner.userId,
+                firstName: learner.firstName,
+                lastName: learner.lastName,
+                status: learner.status,
+            })) ?? [],
+        } : {}),
+    };
+    return NextResponse.json(kioskUser);
 }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { putUser, getAllUsers, getUsersByRoles } from "@/utils/dynamo";
 import { User } from "@/types/user";
+import { requireAdminApi } from "@/utils/apiAuth";
 
 // -------------------- GET: fetch users (with optional filtering) --------------------
 export async function GET(req: NextRequest) {
+    const unauthorized = await requireAdminApi("read");
+    if (unauthorized) return unauthorized;
     try {
         const { searchParams } = new URL(req.url);
         const rolesParam = searchParams.get("roles");
@@ -27,6 +30,8 @@ export async function GET(req: NextRequest) {
 
 // -------------------- POST: create a new user --------------------
 export async function POST(req: NextRequest) {
+    const unauthorized = await requireAdminApi("edit");
+    if (unauthorized) return unauthorized;
     try {
         const body = await req.json();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { User } from "@/types/user";
+import { KioskUser } from "@/types/user";
 import StatusBadge from "@/components/StatusBadge";
 
 export default function PinEntry() {
     const [pin, setPin] = useState("");
-    const [user, setUser] = useState<User | null>(null);
+    const [user, setUser] = useState<KioskUser | null>(null);
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
     const [selectedActions, setSelectedActions] = useState<
-        { userId: string; status: "In" | "Out"; type: string; actorId: string }[]
+        { userId: string; status: "In" | "Out" }[]
     >([]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,7 +35,7 @@ export default function PinEntry() {
                 setLoading(false);
                 return;
             }
-            const userData: User = await res.json();
+            const userData: KioskUser = await res.json();
             setUser(userData);
         } catch (err) {
             console.error(err);
@@ -54,9 +54,7 @@ export default function PinEntry() {
 
     const toggleAction = (
         userId: string,
-        status: "In" | "Out",
-        type: string,
-        actorId: string
+        status: "In" | "Out"
     ) => {
         setSelectedActions((prev) => {
             const existing = prev.find((a) => a.userId === userId);
@@ -66,7 +64,7 @@ export default function PinEntry() {
             }
             // replace if exists, otherwise add
             const others = prev.filter((a) => a.userId !== userId);
-            return [...others, { userId, status, type, actorId }];
+            return [...others, { userId, status }];
         });
     };
 
@@ -83,27 +81,18 @@ export default function PinEntry() {
             // Perform all updates in parallel
             await Promise.all(
                 selectedActions.map(async (action) => {
-                    const { userId, status, type, actorId } = action;
+                    const { userId, status } = action;
                     const res = await fetch(`/api/users/${userId}/status`, {
                         method: "PATCH",
                         headers: { "Content-Type": "application/json" },
                         body: JSON.stringify({
                             status,
-                            userType: type,
-                            clockedById: actorId,
+                            pin,
                         }),
                     });
                     if (!res.ok) throw new Error(`Failed to update ${userId}`);
                 })
             );
-
-            // Refresh after all updates
-            if (user) {
-                const refreshedUser: User = await fetch(`/api/users/${user.userId}`).then((r) =>
-                    r.json()
-                );
-                setUser(refreshedUser);
-            }
 
             setSelectedActions([]);
         } catch (err) {
@@ -120,12 +109,6 @@ export default function PinEntry() {
         user && user.roles.some((r) => ["staff", "volunteer"].includes(r.toLowerCase()));
 
     const isGuardian = user?.roles.includes("guardian");
-    const userType = user?.roles.includes("staff")
-        ? "staff"
-        : user?.roles.includes("volunteer")
-            ? "volunteer"
-            : "learner";
-
     const isSelected = (userId: string, status: "In" | "Out") =>
         selectedActions.some((a) => a.userId === userId && a.status === status);
 
@@ -179,7 +162,7 @@ export default function PinEntry() {
                         <div className="flex gap-4">
                             <button
                                 onClick={() =>
-                                    toggleAction(user.userId, "In", userType, user.userId)
+                                    toggleAction(user.userId, "In")
                                 }
                                 className={`px-6 py-3 text-xl font-semibold rounded ${
                                     isSelected(user.userId, "In")
@@ -191,7 +174,7 @@ export default function PinEntry() {
                             </button>
                             <button
                                 onClick={() =>
-                                    toggleAction(user.userId, "Out", userType, user.userId)
+                                    toggleAction(user.userId, "Out")
                                 }
                                 className={`px-6 py-3 text-xl font-semibold rounded ${
                                     isSelected(user.userId, "Out")
@@ -227,7 +210,7 @@ export default function PinEntry() {
                                         <div className="flex gap-4">
                                             <button
                                                 onClick={() =>
-                                                    toggleAction(learner.userId, "In", "learner", user.userId)
+                                                    toggleAction(learner.userId, "In")
                                                 }
                                                 className={`px-4 py-2 rounded ${
                                                     isSelected(learner.userId, "In")
@@ -239,7 +222,7 @@ export default function PinEntry() {
                                             </button>
                                             <button
                                                 onClick={() =>
-                                                    toggleAction(learner.userId, "Out", "learner", user.userId)
+                                                    toggleAction(learner.userId, "Out")
                                                 }
                                                 className={`px-4 py-2 rounded ${
                                                     isSelected(learner.userId, "Out")

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -24,6 +24,10 @@ export interface RegularUser extends BaseUser {
 // Final User type
 export type User = GuardianUser | RegularUser;
 
+export type KioskUser = Pick<BaseUser, "userId" | "firstName" | "lastName" | "roles" | "status" | "lastClockTransaction"> & {
+    learners?: Array<Pick<BaseUser, "userId" | "firstName" | "lastName" | "status">>;
+};
+
 // Type guard helper
 export function isGuardian(user: User): user is GuardianUser {
     return user.roles.includes("guardian");

--- a/src/utils/apiAuth.ts
+++ b/src/utils/apiAuth.ts
@@ -18,3 +18,16 @@ export const requireSession = async (): Promise<NextResponse | null> => {
 
     return null;
 };
+
+export const requireAdminApi = async (
+    access: "read" | "edit" = "read"
+): Promise<NextResponse | null> => {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (access === "edit" && session.user.adminLevel !== "edit") {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return null;
+};


### PR DESCRIPTION
## What changed

- require authenticated admin access for user reads and `edit` access for user mutations
- preserve omitted roles and learner assignments in partial PATCH requests
- return a restricted, kiosk-safe user shape from PIN lookup
- validate kiosk clock actions against the entered PIN and guardian/learner relationship
- derive the attendance role and clocking actor on the server instead of trusting client input

## Why

The user-management page was protected, but its API routes were directly accessible without authorization. Public lookups also returned full user records, and partial PATCH requests could clear roles and learner assignments. The kiosk clock endpoint trusted caller-controlled identity and role fields.

## Impact

Administrative data and mutations are now protected while the public PIN-based kiosk flow remains available. Read-only administrators retain read access, and only edit-level administrators can change users.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --check`
