### PR TITLE
Fix authentication redirect loop

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -34,7 +34,6 @@ export const authOptions: AuthOptions = {
         },
     },
     pages: {
-        signIn: "/auth/signin",
         error: "/auth/unauthorized", // redirect non-admins here
     },
 }


### PR DESCRIPTION
## What changed

- remove the custom NextAuth sign-in route that pointed to a page that does not exist
- allow NextAuth to serve its built-in provider sign-in page

## Root cause

`/api/auth/signin` redirected to `/auth/signin`, while the missing `/auth/signin` route redirected back to `/api/auth/signin`. The callback URL grew on every pass, producing an infinite authentication loop.

## Validation

- `npm run lint`
- `npm run build`
- local production redirect trace: `/reports` redirects once to `/api/auth/signin`, which returns HTTP 200
- `git diff --check`
