### PR TITLE
Limit authentication to admin routes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,23 @@
-export { default } from "next-auth/middleware";
+import { withAuth } from "next-auth/middleware";
 
+const isAdminRoute = (pathname: string) =>
+    pathname === "/users" ||
+    pathname.startsWith("/users/") ||
+    pathname === "/reports" ||
+    pathname.startsWith("/reports/");
+
+export default withAuth({
+    callbacks: {
+        authorized: ({ token, req }) =>
+            !isAdminRoute(req.nextUrl.pathname) || Boolean(token),
+    },
+});
+
+/*
+ * Keep the public-route decision in the callback as well as the matcher. This
+ * prevents a framework or deployment adapter from accidentally applying admin
+ * authentication to the kiosk home page.
+ */
 export const config = {
-    matcher: ["/dashboard/:path*", "/reports/:path*"], // protected routes
+    matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
 };


### PR DESCRIPTION
## What changed

- replace the default NextAuth middleware re-export with an explicit authorization callback
- always allow public routes, including the kiosk root and PIN clock APIs
- require a NextAuth token only for `/users` and `/reports`
- retain an explicit in-code public-route decision as a safeguard against deployment adapters applying middleware more broadly than the matcher

## Root cause

In production, the re-exported NextAuth middleware was being applied to `/` despite the narrow matcher configuration, redirecting the kiosk home page to administrator sign-in.

## Validation

- `npm run lint`
- `npm run build`
- production-mode route trace:
  - `/` returns HTTP 200
  - `/api/users/by-pin` reaches the API handler without an auth redirect
  - `/reports` redirects to `/api/auth/signin`
- `git diff --check`
