### PR TITLE
Normalize Amplify domain names

### DIFF
--- a/terraform/modules/school/amplify.tf
+++ b/terraform/modules/school/amplify.tf
@@ -31,7 +31,7 @@ resource "aws_amplify_branch" "production" {
 
 resource "aws_amplify_domain_association" "school" {
   app_id                = aws_amplify_app.app.id
-  domain_name           = "${var.school_id}.clockin.click"
+  domain_name           = "${lower(var.school_id)}.clockin.click"
   wait_for_verification = true
 
   sub_domain {


### PR DESCRIPTION
## Summary

- normalize the Amplify custom domain to lowercase
- preserve the original school identifier used as the Terraform `for_each` key

## Why

Amplify normalizes DNS hostnames to lowercase. Passing a mixed-case school identifier caused Terraform to wait for a domain association using a name that Amplify could not return consistently.

## Impact

`WildFlower` continues to identify the existing Terraform module and application resources, while its custom hostname is created as `wildflower.clockin.click`. This avoids replacing resources keyed by the original school identifier.

## Validation

- `git diff --cached --check`
- Terraform CLI was unavailable locally; the deployment workflow will run Terraform against this change.
