### PR TITLE
Refresh kiosk experience

### DIFF
--- a/src/app/api/users/[id]/status/route.ts
+++ b/src/app/api/users/[id]/status/route.ts
@@ -5,6 +5,7 @@ import {
     updateUserStatus,
     logTimeClock,
 } from "@/utils/dynamo";
+import { isAllowedMockClock, isLocalKioskMockEnabled } from "@/utils/kioskMock";
 
 export async function PATCH(
     req: NextRequest,
@@ -18,6 +19,13 @@ export async function PATCH(
     }
     if (typeof pin !== "string" || !/^\d{4}$/.test(pin)) {
         return NextResponse.json({ error: "A valid PIN is required" }, { status: 401 });
+    }
+
+    if (isLocalKioskMockEnabled) {
+        if (!isAllowedMockClock(pin, id)) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+        return NextResponse.json({ userId: id, status, mocked: true });
     }
 
     try {

--- a/src/app/api/users/by-pin/route.ts
+++ b/src/app/api/users/by-pin/route.ts
@@ -1,10 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserByPin } from "@/utils/dynamo";
 import { KioskUser } from "@/types/user";
+import { getMockKioskUser, isLocalKioskMockEnabled } from "@/utils/kioskMock";
 
 export async function GET(req: NextRequest) {
     const pin = req.nextUrl.searchParams.get("pin");
     if (!pin) return NextResponse.json({ error: "Pin is required" }, { status: 400 });
+
+    if (isLocalKioskMockEnabled) {
+        const mockUser = getMockKioskUser(pin);
+        return mockUser
+            ? NextResponse.json(mockUser)
+            : NextResponse.json({ error: "Try demo PIN 2468 or 1357" }, { status: 404 });
+    }
 
     const user = await getUserByPin(pin);
     if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,262 +1,246 @@
 "use client";
 
 import { useState } from "react";
+import { ArrowLeft, Check, Clock3, Delete, LogIn, LogOut, ShieldCheck } from "lucide-react";
 import { KioskUser } from "@/types/user";
 import StatusBadge from "@/components/StatusBadge";
+
+type ClockAction = { userId: string; status: "In" | "Out" };
 
 export default function PinEntry() {
     const [pin, setPin] = useState("");
     const [user, setUser] = useState<KioskUser | null>(null);
     const [error, setError] = useState("");
+    const [confirmation, setConfirmation] = useState("");
     const [loading, setLoading] = useState(false);
-    const [selectedActions, setSelectedActions] = useState<
-        { userId: string; status: "In" | "Out" }[]
-    >([]);
+    const [selectedActions, setSelectedActions] = useState<ClockAction[]>([]);
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const value = e.target.value.replace(/\D/g, "");
-        if (value.length <= 4) setPin(value);
+    const updatePin = (value: string) => {
+        setPin(value.replace(/\D/g, "").slice(0, 4));
         setError("");
+        setConfirmation("");
     };
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
         if (pin.length !== 4) {
-            setError("Please enter a 4-digit PIN");
+            setError("Enter all four digits to continue.");
             return;
         }
+
         setLoading(true);
         setError("");
         try {
-            const res = await fetch(`/api/users/by-pin?pin=${encodeURIComponent(pin)}`);
-            if (!res.ok) {
-                const data = await res.json();
-                setError(data.error || "User not found");
-                setLoading(false);
+            const response = await fetch(`/api/users/by-pin?pin=${encodeURIComponent(pin)}`);
+            const data = await response.json();
+            if (!response.ok) {
+                setError(data.error || "We couldn’t find that PIN. Try again.");
                 return;
             }
-            const userData: KioskUser = await res.json();
-            setUser(userData);
+            setUser(data as KioskUser);
         } catch (err) {
             console.error(err);
-            setError("Failed to fetch user");
+            setError("We couldn’t connect. Check your connection and try again.");
         } finally {
             setLoading(false);
         }
     };
 
-    const clearPin = () => {
+    const startOver = () => {
         setPin("");
         setUser(null);
         setError("");
         setSelectedActions([]);
     };
 
-    const toggleAction = (
-        userId: string,
-        status: "In" | "Out"
-    ) => {
-        setSelectedActions((prev) => {
-            const existing = prev.find((a) => a.userId === userId);
-            if (existing?.status === status) {
-                // deselect if same
-                return prev.filter((a) => a.userId !== userId);
-            }
-            // replace if exists, otherwise add
-            const others = prev.filter((a) => a.userId !== userId);
-            return [...others, { userId, status }];
+    const toggleAction = (userId: string, status: "In" | "Out") => {
+        setError("");
+        setSelectedActions((current) => {
+            const existing = current.find((action) => action.userId === userId);
+            if (existing?.status === status) return current.filter((action) => action.userId !== userId);
+            return [...current.filter((action) => action.userId !== userId), { userId, status }];
         });
     };
 
     const handleClockSubmit = async () => {
         if (selectedActions.length === 0) {
-            setError("Please select at least one Clock In/Out action first.");
+            setError("Choose Clock in or Clock out for at least one person.");
             return;
         }
 
         setLoading(true);
         setError("");
-
         try {
-            // Perform all updates in parallel
-            await Promise.all(
-                selectedActions.map(async (action) => {
-                    const { userId, status } = action;
-                    const res = await fetch(`/api/users/${userId}/status`, {
-                        method: "PATCH",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({
-                            status,
-                            pin,
-                        }),
-                    });
-                    if (!res.ok) throw new Error(`Failed to update ${userId}`);
-                })
-            );
+            await Promise.all(selectedActions.map(async ({ userId, status }) => {
+                const response = await fetch(`/api/users/${userId}/status`, {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ status, pin }),
+                });
+                if (!response.ok) throw new Error(`Failed to update ${userId}`);
+            }));
 
-            setSelectedActions([]);
+            const count = selectedActions.length;
+            startOver();
+            setConfirmation(`${count === 1 ? "Attendance" : `Attendance for ${count} people`} updated successfully.`);
         } catch (err) {
             console.error(err);
-            setError("One or more updates failed.");
+            setError("Nothing was cleared. Please try submitting again.");
         } finally {
             setLoading(false);
-            clearPin();
-            setUser(null);
         }
     };
 
-    const canClockSelf =
-        user && user.roles.some((r) => ["staff", "volunteer"].includes(r.toLowerCase()));
-
-    const isGuardian = user?.roles.includes("guardian");
+    const canClockSelf = user?.roles.some((role) => ["staff", "volunteer"].includes(role.toLowerCase()));
+    const isGuardian = user?.roles.some((role) => role.toLowerCase() === "guardian");
     const isSelected = (userId: string, status: "In" | "Out") =>
-        selectedActions.some((a) => a.userId === userId && a.status === status);
+        selectedActions.some((action) => action.userId === userId && action.status === status);
 
     return (
-        <div className="flex flex-col items-center min-h-screen p-4 pt-20 bg-gray-100">
-            {!user ? (
-                <form onSubmit={handleSubmit} className="flex flex-col items-center space-y-4">
-                    <h1 className="text-3xl font-bold mb-6">Enter Your PIN</h1>
-                    <input
-                        type="text"
-                        inputMode="numeric"
-                        pattern="\d*"
-                        maxLength={4}
-                        value={pin}
-                        onChange={handleChange}
-                        autoFocus
-                        className="w-60 text-center text-5xl border rounded-md p-2 shadow focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    {error && <p className="text-red-500">{error}</p>}
-                    <div className="flex space-x-2">
-                        <button
-                            type="button"
-                            onClick={clearPin}
-                            className="px-4 py-2 text-2xl bg-gray-300 rounded hover:bg-gray-400 text-black cursor-pointer"
-                        >
-                            Clear
-                        </button>
-                        <button
-                            type="submit"
-                            className="px-4 py-2 w-35 text-2xl bg-blue-500 text-white rounded hover:bg-blue-600 cursor-pointer"
-                            disabled={loading}
-                        >
-                            {loading ? "Loading..." : "Lookup"}
-                        </button>
-                    </div>
-                </form>
-            ) : (
-                <div className="bg-white p-6 rounded shadow text-center flex flex-col gap-4 items-center w-full max-w-2xl">
-                    <h2 className="text-3xl font-semibold">
-                        Welcome, {user.firstName} {user.lastName}!
-                    </h2>
-                    <p>Roles: {user.roles.join(", ")}</p>
-                    {user.status && (
-                        <p className="text-gray-500 text-sm">
-                            Current status: <StatusBadge status={user.status} />
-                        </p>
-                    )}
-
-                    {/* SELF CLOCKING */}
-                    {canClockSelf && (
-                        <div className="flex gap-4">
-                            <button
-                                onClick={() =>
-                                    toggleAction(user.userId, "In")
-                                }
-                                className={`px-6 py-3 text-xl font-semibold rounded ${
-                                    isSelected(user.userId, "In")
-                                        ? "bg-green-600 text-white"
-                                        : "bg-gray-200 hover:bg-gray-300 border-green-600 border"
-                                }`}
-                            >
-                                Clock In
-                            </button>
-                            <button
-                                onClick={() =>
-                                    toggleAction(user.userId, "Out")
-                                }
-                                className={`px-6 py-3 text-xl font-semibold rounded ${
-                                    isSelected(user.userId, "Out")
-                                        ? "bg-red-600 text-white"
-                                        : "bg-gray-200 hover:bg-gray-300 border-red-600 border"
-                                }`}
-                            >
-                                Clock Out
-                            </button>
-                        </div>
-                    )}
-
-                    {/* LEARNER CLOCKING */}
-                    {isGuardian && (user.learners?.length ?? 0) > 0 && (
-                        <div className="mt-4 w-full">
-                            <h3 className="font-semibold mb-2">Your Learners</h3>
-                            <ul className="space-y-2">
-                                {user.learners?.map((learner) => (
-                                    <li
-                                        key={learner.userId}
-                                        className="flex justify-between items-center border text-2xl p-2 rounded"
-                                    >
-                    <span>
-                      {learner.firstName} {learner.lastName}{" "}
-                        {learner.status ? (
-                            <p className="text-gray-500 text-sm">
-                                Current status: <StatusBadge status={learner.status} />
+        <div className="kiosk-shell min-h-[calc(100vh-5rem)] px-4 py-8 sm:px-6 sm:py-12">
+            <div className="mx-auto max-w-3xl">
+                {!user ? (
+                    <div className="grid items-center gap-8 lg:grid-cols-[1fr_25rem]">
+                        <section className="hidden lg:block">
+                            <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-3 py-1.5 text-sm font-bold text-emerald-800">
+                                <ShieldCheck className="h-4 w-4" /> Secure school check-in
+                            </div>
+                            <h1 className="text-5xl font-black leading-[1.08] tracking-tight text-slate-900">
+                                A simple start<br />to the school day.
+                            </h1>
+                            <p className="mt-5 max-w-md text-lg leading-8 text-slate-600">
+                                Enter your family PIN, choose who is arriving or leaving, and you’re done.
                             </p>
-                        ) : (
-                            ""
-                        )}
-                    </span>
-                                        <div className="flex gap-4">
-                                            <button
-                                                onClick={() =>
-                                                    toggleAction(learner.userId, "In")
-                                                }
-                                                className={`px-4 py-2 rounded ${
-                                                    isSelected(learner.userId, "In")
-                                                        ? "bg-green-600 text-white"
-                                                        : "bg-gray-200 hover:bg-gray-300 border-green-600 border"
-                                                }`}
-                                            >
-                                                In
-                                            </button>
-                                            <button
-                                                onClick={() =>
-                                                    toggleAction(learner.userId, "Out")
-                                                }
-                                                className={`px-4 py-2 rounded ${
-                                                    isSelected(learner.userId, "Out")
-                                                        ? "bg-red-600 text-white"
-                                                        : "bg-gray-200 hover:bg-gray-300 border-red-600 border"
-                                                }`}
-                                            >
-                                                Out
-                                            </button>
-                                        </div>
-                                    </li>
+                        </section>
+
+                        <form onSubmit={handleSubmit} className="surface-card p-5 sm:p-7">
+                            <div className="mb-6 text-center">
+                                <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700">
+                                    <Clock3 className="h-6 w-6" />
+                                </div>
+                                <h1 className="text-2xl font-black text-slate-900 sm:text-3xl">Enter your PIN</h1>
+                                <p className="mt-2 text-sm text-slate-500">Use your private 4-digit family or staff PIN.</p>
+                            </div>
+
+                            <label htmlFor="pin" className="sr-only">Four-digit PIN</label>
+                            <input
+                                id="pin"
+                                type="password"
+                                inputMode="numeric"
+                                pattern="[0-9]*"
+                                autoComplete="off"
+                                maxLength={4}
+                                value={pin}
+                                onChange={(event) => updatePin(event.target.value)}
+                                autoFocus
+                                className="mb-4 h-16 w-full rounded-2xl border-2 border-slate-200 bg-slate-50 text-center font-mono text-4xl tracking-[0.65em] text-slate-900 caret-emerald-600 outline-none transition focus:border-emerald-500 focus:bg-white focus:ring-4 focus:ring-emerald-100"
+                            />
+
+                            <div className="grid grid-cols-3 gap-2" aria-label="PIN keypad">
+                                {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((digit) => (
+                                    <button key={digit} type="button" onClick={() => updatePin(`${pin}${digit}`)} className="keypad-button">
+                                        {digit}
+                                    </button>
                                 ))}
-                            </ul>
+                                <button type="button" onClick={() => updatePin("")} className="keypad-button text-sm font-bold text-slate-500">Clear</button>
+                                <button type="button" onClick={() => updatePin(`${pin}0`)} className="keypad-button">0</button>
+                                <button type="button" aria-label="Delete last digit" onClick={() => updatePin(pin.slice(0, -1))} className="keypad-button text-slate-500">
+                                    <Delete className="h-5 w-5" />
+                                </button>
+                            </div>
+
+                            {(error || confirmation) && (
+                                <div role="status" className={`mt-4 rounded-xl px-4 py-3 text-sm font-bold ${error ? "bg-rose-50 text-rose-700" : "bg-emerald-50 text-emerald-700"}`}>
+                                    {error || confirmation}
+                                </div>
+                            )}
+
+                            <button type="submit" disabled={loading || pin.length !== 4} className="primary-action mt-4 w-full">
+                                {loading ? "Looking up…" : "Continue"}
+                            </button>
+                        </form>
+                    </div>
+                ) : (
+                    <section className="surface-card overflow-hidden">
+                        <header className="border-b border-slate-100 bg-white px-5 py-5 sm:px-8">
+                            <button type="button" onClick={startOver} className="mb-4 inline-flex items-center gap-2 text-sm font-bold text-slate-500 hover:text-slate-900">
+                                <ArrowLeft className="h-4 w-4" /> Use a different PIN
+                            </button>
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                                <div>
+                                    <p className="text-sm font-bold uppercase tracking-widest text-emerald-700">Welcome</p>
+                                    <h1 className="mt-1 text-3xl font-black text-slate-900">{user.firstName} {user.lastName}</h1>
+                                </div>
+                                {user.status && <div className="flex items-center gap-2 text-sm text-slate-500">Your current status <StatusBadge status={user.status} /></div>}
+                            </div>
+                        </header>
+
+                        <div className="space-y-6 p-5 sm:p-8">
+                            <p className="text-base text-slate-600">Choose an action for each person who is arriving or leaving.</p>
+
+                            {canClockSelf && (
+                                <PersonAction
+                                    name={`${user.firstName} ${user.lastName}`}
+                                    status={user.status}
+                                    selectedIn={isSelected(user.userId, "In")}
+                                    selectedOut={isSelected(user.userId, "Out")}
+                                    onSelect={(status) => toggleAction(user.userId, status)}
+                                />
+                            )}
+
+                            {isGuardian && (user.learners?.length ?? 0) > 0 && (
+                                <div className="space-y-3">
+                                    <h2 className="text-sm font-black uppercase tracking-wider text-slate-500">Your learners</h2>
+                                    {user.learners?.map((learner) => (
+                                        <PersonAction
+                                            key={learner.userId}
+                                            name={`${learner.firstName} ${learner.lastName}`}
+                                            status={learner.status}
+                                            selectedIn={isSelected(learner.userId, "In")}
+                                            selectedOut={isSelected(learner.userId, "Out")}
+                                            onSelect={(status) => toggleAction(learner.userId, status)}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+
+                            {error && <div role="alert" className="rounded-xl bg-rose-50 px-4 py-3 text-sm font-bold text-rose-700">{error}</div>}
+
+                            <div className="flex flex-col-reverse gap-3 border-t border-slate-100 pt-6 sm:flex-row sm:justify-end">
+                                <button type="button" onClick={startOver} className="secondary-action">Cancel</button>
+                                <button type="button" onClick={handleClockSubmit} disabled={loading || selectedActions.length === 0} className="primary-action sm:min-w-52">
+                                    {loading ? "Updating…" : <><Check className="h-5 w-5" /> Confirm {selectedActions.length || ""} {selectedActions.length === 1 ? "change" : "changes"}</>}
+                                </button>
+                            </div>
                         </div>
-                    )}
+                    </section>
+                )}
+            </div>
+        </div>
+    );
+}
 
-                    {/* SUBMIT ALL */}
-                    <button
-                        onClick={handleClockSubmit}
-                        disabled={loading || selectedActions.length === 0}
-                        className="mt-4 px-6 py-3 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-300"
-                    >
-                        {loading ? "Processing..." : "Submit All"}
-                    </button>
-
-                    <button
-                        type="button"
-                        onClick={clearPin}
-                        className="mt-2 px-4 py-2 bg-gray-300 rounded hover:bg-gray-400 text-black cursor-pointer"
-                    >
-                        Back
-                    </button>
-                </div>
-            )}
+function PersonAction({ name, status, selectedIn, selectedOut, onSelect }: {
+    name: string;
+    status?: string;
+    selectedIn: boolean;
+    selectedOut: boolean;
+    onSelect: (status: "In" | "Out") => void;
+}) {
+    return (
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 sm:flex sm:items-center sm:justify-between sm:gap-5">
+            <div className="mb-4 min-w-0 sm:mb-0">
+                <p className="truncate text-lg font-black text-slate-900">{name}</p>
+                <div className="mt-1 flex items-center gap-2 text-sm text-slate-500">Currently <StatusBadge status={status} /></div>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:w-64">
+                <button type="button" aria-pressed={selectedIn} onClick={() => onSelect("In")} className={`clock-choice ${selectedIn ? "clock-choice-in-active" : ""}`}>
+                    <LogIn className="h-5 w-5" /> Clock in
+                </button>
+                <button type="button" aria-pressed={selectedOut} onClick={() => onSelect("Out")} className={`clock-choice ${selectedOut ? "clock-choice-out-active" : ""}`}>
+                    <LogOut className="h-5 w-5" /> Clock out
+                </button>
+            </div>
         </div>
     );
 }

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 import { signIn, signOut, useSession } from "next-auth/react";
+import { LogIn, LogOut } from "lucide-react";
 
 export default function LoginButton() {
     const { data: session } = useSession();
 
     if (session) {
         return (
-            <div className="flex items-center gap-4">
-                <span className="text-gray-700">Hello, {session.user?.name}</span>
+            <div className="flex items-center gap-2">
+                <span className="hidden text-sm font-bold text-slate-600 lg:inline">{session.user?.name}</span>
                 <button
                     onClick={() => signOut()}
-                    className="rounded bg-red-500 px-3 py-1 text-white cursor-pointer"
+                    className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-slate-200 px-3 text-sm font-bold text-slate-700 transition hover:bg-slate-100"
                 >
-                    Sign out
+                    <LogOut className="h-4 w-4" /> <span className="hidden sm:inline">Sign out</span>
                 </button>
             </div>
         );
@@ -21,9 +22,9 @@ export default function LoginButton() {
     return (
         <button
             onClick={() => signIn("google")}
-            className="rounded bg-blue-600 px-3 py-1 text-white cursor-pointer"
+            className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-slate-200 px-3 text-sm font-bold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
         >
-           Administrator Sign in
+           <LogIn className="h-4 w-4" /> <span className="hidden sm:inline">Admin sign in</span>
         </button>
     );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,33 +4,36 @@ import Link from "next/link";
 import LoginButton from "./LoginButton";
 import { useSession } from "next-auth/react";
 import Image from "next/image";
+import { BarChart3, Users } from "lucide-react";
 
 export default function Navbar() {
     const { data: session } = useSession();
 
     return (
-        <nav className="flex items-center justify-between bg-white drop-shadow-xl px-6 py-3">
+        <nav className="relative z-20 flex min-h-20 items-center justify-between border-b border-slate-200/80 bg-white/90 px-4 backdrop-blur sm:px-6">
             {/* Left side - App name / Logo */}
-            <div className="text-xl font-bold text-gray-800">
-                <Link href="/">
+            <div className="shrink-0">
+                <Link href="/" className="inline-flex items-center rounded-lg" aria-label="Clockin.Click home">
                     <Image
                         src={"/images/logo.png"}
                         alt={"School logo"}
-                        width={250}
-                        height={250}
+                        width={180}
+                        height={64}
+                        className="h-12 w-auto object-contain"
+                        priority
                     />
                 </Link>
             </div>
 
             {/* Center - Navigation links */}
-            <div className="flex gap-6 text-gray-700">
+            <div className="ml-auto mr-3 flex items-center gap-1 text-slate-600 sm:mr-6">
                 {session && (
                     <>
-                        <Link href="/users" className="hover:text-blue-600">
-                            User Management
+                        <Link href="/users" className="inline-flex min-h-10 items-center gap-2 rounded-lg px-3 text-sm font-bold hover:bg-slate-100 hover:text-slate-900">
+                            <Users className="h-4 w-4" /> <span className="hidden md:inline">Users</span>
                         </Link>
-                        <Link href="/reports" className="hover:text-blue-600">
-                            Reports
+                        <Link href="/reports" className="inline-flex min-h-10 items-center gap-2 rounded-lg px-3 text-sm font-bold hover:bg-slate-100 hover:text-slate-900">
+                            <BarChart3 className="h-4 w-4" /> <span className="hidden md:inline">Reports</span>
                         </Link>
                     </>
                 )}

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -191,7 +191,47 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-slate-50 text-slate-900 antialiased;
+  }
+  button, a, input, select {
+    @apply focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200;
+  }
+}
+
+@layer components {
+  .kiosk-shell {
+    background:
+      radial-gradient(circle at 15% 15%, rgb(209 250 229 / 0.8), transparent 32rem),
+      radial-gradient(circle at 90% 85%, rgb(224 242 254 / 0.75), transparent 30rem),
+      #f8fafc;
+  }
+
+  .surface-card {
+    @apply rounded-3xl border border-white/80 bg-white/95 shadow-[0_24px_70px_-32px_rgba(15,23,42,0.35)];
+  }
+
+  .keypad-button {
+    @apply flex h-14 items-center justify-center rounded-xl border border-slate-200 bg-white text-xl font-black text-slate-800 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-300 hover:bg-emerald-50 active:translate-y-0 active:bg-emerald-100;
+  }
+
+  .primary-action {
+    @apply inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-emerald-700 px-5 py-3 text-base font-black text-white shadow-sm transition hover:bg-emerald-800 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:text-slate-500 disabled:shadow-none;
+  }
+
+  .secondary-action {
+    @apply inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 py-3 text-base font-bold text-slate-700 transition hover:bg-slate-50;
+  }
+
+  .clock-choice {
+    @apply flex min-h-12 items-center justify-center gap-2 rounded-xl border-2 border-slate-200 bg-slate-50 px-3 py-2 text-sm font-black text-slate-700 transition hover:border-slate-300 hover:bg-white;
+  }
+
+  .clock-choice-in-active {
+    @apply border-emerald-600 bg-emerald-600 text-white hover:border-emerald-700 hover:bg-emerald-700;
+  }
+
+  .clock-choice-out-active {
+    @apply border-amber-600 bg-amber-600 text-white hover:border-amber-700 hover:bg-amber-700;
   }
 }
 

--- a/src/utils/kioskMock.ts
+++ b/src/utils/kioskMock.ts
@@ -1,0 +1,33 @@
+import { KioskUser } from "@/types/user";
+
+export const isLocalKioskMockEnabled =
+    process.env.NODE_ENV !== "production" && process.env.LOCAL_KIOSK_MOCK === "true";
+
+const MOCK_USERS: Record<string, KioskUser> = {
+    "2468": {
+        userId: "mock-guardian",
+        firstName: "Jordan",
+        lastName: "Rivera",
+        roles: ["guardian"],
+        learners: [
+            { userId: "mock-learner-1", firstName: "Maya", lastName: "Rivera", status: "Out" },
+            { userId: "mock-learner-2", firstName: "Theo", lastName: "Rivera", status: "In" },
+        ],
+    },
+    "1357": {
+        userId: "mock-staff",
+        firstName: "Alex",
+        lastName: "Morgan",
+        roles: ["staff"],
+        status: "Out",
+    },
+};
+
+export const getMockKioskUser = (pin: string) => MOCK_USERS[pin] ?? null;
+
+export const isAllowedMockClock = (pin: string, userId: string) => {
+    const actor = getMockKioskUser(pin);
+    if (!actor) return false;
+    if (actor.userId === userId) return true;
+    return actor.learners?.some((learner) => learner.userId === userId) ?? false;
+};


### PR DESCRIPTION
## Summary

- redesign the public kiosk around a touch-friendly four-digit keypad
- present clear per-person clock-in and clock-out choices with an explicit confirmation step
- refresh the shared navigation, typography, colors, spacing, and keyboard focus states
- retain selections after failed updates and show clear success/error feedback
- add an opt-in, development-only kiosk fixture for testing without DynamoDB writes

## Why

The existing kiosk resembled a generic form and made families select actions before submitting an ambiguously labeled batch. The new experience gives the primary attendance task stronger visual hierarchy, plain-language guidance, and larger touch targets while keeping administrative navigation secondary.

## Impact

Families and staff get a faster, clearer mobile and tablet check-in flow. Failed updates no longer discard the user’s selections. The mock fixture is gated behind both a non-production runtime and `LOCAL_KIOSK_MOCK=true`, so it cannot be enabled in production.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --cached --check`
- manual local review with guardian PIN `2468` and staff PIN `1357`
