### PR TITLE
Prioritize school branding

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -7,8 +7,8 @@ frontend:
     build:
       commands:
         - aws secretsmanager get-secret-value --secret-id "$SECRET_NAME" --query SecretString --output text > /tmp/app-secrets.json
+        - aws s3 cp "s3://$ASSETS_BUCKET/$SCHOOL_NAME/images/logo.png" public/images/school-logo.png || true
         - node scripts/write-amplify-env.mjs /tmp/app-secrets.json
-        - aws s3 cp "s3://$ASSETS_BUCKET/$SCHOOL_NAME/images/logo.png" public/images/logo.png || true
         - npm run build
   artifacts:
     baseDirectory: .next

--- a/scripts/write-amplify-env.mjs
+++ b/scripts/write-amplify-env.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 
 const secretFile = process.argv[2];
 if (!secretFile) throw new Error("Expected the Secrets Manager JSON file path");
@@ -8,6 +8,9 @@ const runtime = {
     ...secrets,
     SCHOOL_NAME: process.env.SCHOOL_NAME,
     NEXT_PUBLIC_SCHOOL_NAME: process.env.SCHOOL_NAME,
+    ...(existsSync("public/images/school-logo.png")
+        ? { NEXT_PUBLIC_SCHOOL_LOGO: "/images/school-logo.png" }
+        : {}),
     NEXTAUTH_URL: `https://${process.env.SCHOOL_NAME}.clockin.click`,
 };
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,26 +5,44 @@ import LoginButton from "./LoginButton";
 import { useSession } from "next-auth/react";
 import Image from "next/image";
 import { BarChart3, Users } from "lucide-react";
+import { useState } from "react";
 
 export default function Navbar() {
     const { data: session } = useSession();
+    const configuredSchoolLogo = process.env.NEXT_PUBLIC_SCHOOL_LOGO;
+    const [showSchoolLogo, setShowSchoolLogo] = useState(Boolean(configuredSchoolLogo));
 
     return (
         <nav className="relative z-20 flex min-h-20 items-center justify-between border-b border-slate-200/80 bg-white/90 px-4 backdrop-blur sm:px-6">
-            {/* Left side - App name / Logo */}
+            {/* The school owns the primary brand position. Clockin.Click remains
+                the quiet platform signature in the footer and browser chrome. */}
             <div className="shrink-0">
-                <Link href="/" className="inline-flex items-center gap-2.5 rounded-lg" aria-label="Clockin.Click home">
-                    <Image
-                        src={"/images/logo.png"}
-                        alt=""
-                        width={48}
-                        height={48}
-                        className="h-11 w-11 object-contain"
-                        priority
-                    />
-                    <span className="text-lg font-black tracking-tight text-slate-900 sm:text-xl">
-                        Clockin<span className="text-emerald-700">.Click</span>
-                    </span>
+                <Link href="/" className="inline-flex items-center rounded-lg" aria-label="School time clock home">
+                    {showSchoolLogo && configuredSchoolLogo ? (
+                        <Image
+                            src={configuredSchoolLogo}
+                            alt="School logo"
+                            width={200}
+                            height={64}
+                            className="h-12 w-auto max-w-[11rem] object-contain object-left sm:max-w-[13rem]"
+                            onError={() => setShowSchoolLogo(false)}
+                            priority
+                        />
+                    ) : (
+                        <span className="inline-flex items-center gap-2.5">
+                            <Image
+                                src="/images/logo.png"
+                                alt=""
+                                width={48}
+                                height={48}
+                                className="h-11 w-11 object-contain"
+                                priority
+                            />
+                            <span className="text-lg font-black tracking-tight text-slate-900 sm:text-xl">
+                                Clockin<span className="text-emerald-700">.Click</span>
+                            </span>
+                        </span>
+                    )}
                 </Link>
             </div>
 


### PR DESCRIPTION
## Summary

- give the school logo the primary navbar position in deployed school environments
- keep the new Clockin.Click mark and wordmark as the localhost and missing-school-logo fallback
- download Amplify school branding to a separate `school-logo.png` asset
- fall back automatically if the configured school image cannot load

## Why

The previous build process overwrote the Clockin.Click product mark with each school logo, while the navbar simultaneously rendered a competing Clockin.Click wordmark. Separating the assets makes the intended hierarchy explicit and prevents one identity from overwriting the other.

## Impact

School deployments lead with their own branding. Local development remains clearly branded as Clockin.Click, and deployments without a valid school asset degrade gracefully instead of showing a broken image.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --cached --check`
- manual localhost review of the Clockin.Click fallback
