### PR TITLE
Deploy marketing site with Amplify

### DIFF
--- a/terraform/marketing.tf
+++ b/terraform/marketing.tf
@@ -1,0 +1,57 @@
+resource "aws_amplify_app" "marketing" {
+  name                     = "${var.project_name}-marketing"
+  repository               = var.marketing_repository_url
+  access_token             = var.github_access_token
+  platform                 = "WEB_COMPUTE"
+  enable_branch_auto_build = true
+
+  build_spec = <<-YAML
+    version: 1
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - nvm use 22
+            - npm ci
+        build:
+          commands:
+            - npm run build
+      artifacts:
+        baseDirectory: .next
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+          - .next/cache/**/*
+  YAML
+
+  tags = {
+    application = var.project_name
+    site        = "marketing"
+  }
+}
+
+resource "aws_amplify_branch" "marketing_production" {
+  app_id            = aws_amplify_app.marketing.id
+  branch_name       = var.marketing_repository_branch
+  framework         = "Next.js - SSR"
+  stage             = "PRODUCTION"
+  enable_auto_build = true
+}
+
+resource "aws_amplify_domain_association" "marketing" {
+  app_id                = aws_amplify_app.marketing.id
+  domain_name           = var.marketing_domain_name
+  wait_for_verification = true
+
+  sub_domain {
+    branch_name = aws_amplify_branch.marketing_production.branch_name
+    prefix      = ""
+  }
+
+  sub_domain {
+    branch_name = aws_amplify_branch.marketing_production.branch_name
+    prefix      = "www"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,3 +2,14 @@ output "schools_amplify_urls" {
   value = { for school, mod in module.schools : school => mod.amplify_url }
 }
 
+output "marketing_amplify_url" {
+  value = "https://${aws_amplify_branch.marketing_production.branch_name}.${aws_amplify_app.marketing.default_domain}"
+}
+
+output "marketing_custom_urls" {
+  value = [
+    "https://${var.marketing_domain_name}",
+    "https://www.${var.marketing_domain_name}",
+  ]
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,21 @@ variable "repository_branch" {
   default = "main"
 }
 
+variable "marketing_repository_url" {
+  type    = string
+  default = "https://github.com/kottok-technologies/clockin.click-marketing"
+}
+
+variable "marketing_repository_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "marketing_domain_name" {
+  type    = string
+  default = "clockin.click"
+}
+
 variable "github_access_token" {
   type      = string
   sensitive = true


### PR DESCRIPTION
## What changed

- creates a dedicated Amplify app for the Clockin.Click marketing repository
- deploys the marketing repository's main branch as a Next.js production branch
- associates both clockin.click and www.clockin.click with the marketing app
- exposes the Amplify and custom domain URLs as Terraform outputs

## Why

This keeps the public marketing site reproducible alongside the existing school infrastructure while leaving school Amplify applications and Fastmail mail records independent.

## Validation

- git diff --check passed
- Terraform formatting and validation could not be run locally because Terraform is not available on the current shell PATH; the deployment workflow will perform Terraform init and plan after merge/manual dispatch.