### PR TITLE
Associate schools with shared root domain

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,7 @@ module "schools" {
   project_name        = var.project_name
   repository_url      = var.repository_url
   repository_branch   = var.repository_branch
+  domain_name         = var.domain_name
   github_access_token = var.github_access_token
   secret_name         = var.secret_name
   secret_arn          = var.secret_arn

--- a/terraform/modules/school/amplify.tf
+++ b/terraform/modules/school/amplify.tf
@@ -31,11 +31,11 @@ resource "aws_amplify_branch" "production" {
 
 resource "aws_amplify_domain_association" "school" {
   app_id                = aws_amplify_app.app.id
-  domain_name           = "${lower(var.school_id)}.clockin.click"
+  domain_name           = var.domain_name
   wait_for_verification = true
 
   sub_domain {
     branch_name = aws_amplify_branch.production.branch_name
-    prefix      = ""
+    prefix      = lower(var.school_id)
   }
 }

--- a/terraform/modules/school/outputs.tf
+++ b/terraform/modules/school/outputs.tf
@@ -11,5 +11,5 @@ output "amplify_url" {
 }
 
 output "custom_domain" {
-  value = "https://${var.school_id}.clockin.click"
+  value = "https://${lower(var.school_id)}.${var.domain_name}"
 }

--- a/terraform/modules/school/variables.tf
+++ b/terraform/modules/school/variables.tf
@@ -10,6 +10,7 @@ variable "project_name" {
 
 variable "repository_url" { type = string }
 variable "repository_branch" { type = string }
+variable "domain_name" { type = string }
 variable "github_access_token" {
   type      = string
   sensitive = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,11 @@ variable "repository_branch" {
   default = "main"
 }
 
+variable "domain_name" {
+  type    = string
+  default = "clockin.click"
+}
+
 variable "github_access_token" {
   type      = string
   sensitive = true


### PR DESCRIPTION
## What changed

- configures each school Amplify app against the shared clockin.click parent domain
- maps only the lowercased school-name prefix to that school's production branch
- excludes the root by omitting the empty-prefix subdomain mapping
- makes the parent domain a root Terraform variable and updates module outputs

## Why

All Amplify apps need to use the same parent domain model. The marketing app owns the root and www entries, while school apps own only their individual subdomains.

## Deployment order

Do not merge this PR until the marketing domain PR is merged and the clockin.click association reports AVAILABLE.

## Validation

- git diff --check passed
- the PR workflow runs Terraform fmt, validate, and plan against production state