### PR TITLE
Add configurable attendance schedules

### DIFF
--- a/src/app/api/settings/schedule/route.ts
+++ b/src/app/api/settings/schedule/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { requireAdminApi } from "@/utils/apiAuth";
+import { getSchoolSchedule, putSchoolSchedule } from "@/utils/dynamo";
+import type { SchoolSchedule } from "@/types/schedule";
+
+const TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+const isValidSchedule = (value: unknown): value is SchoolSchedule => {
+    if (!value || typeof value !== "object") return false;
+    const schedule = value as SchoolSchedule;
+    return [schedule.student, schedule.staff].every((window) =>
+        Boolean(window) &&
+        TIME_PATTERN.test(window.startTime) &&
+        TIME_PATTERN.test(window.endTime) &&
+        window.startTime < window.endTime
+    );
+};
+
+export async function GET() {
+    const unauthorized = await requireAdminApi("read");
+    if (unauthorized) return unauthorized;
+
+    try {
+        return NextResponse.json(await getSchoolSchedule());
+    } catch (error) {
+        console.error("Failed to load school schedule:", error);
+        return NextResponse.json({ error: "Failed to load school schedule" }, { status: 500 });
+    }
+}
+
+export async function PUT(request: Request) {
+    const unauthorized = await requireAdminApi("edit");
+    if (unauthorized) return unauthorized;
+
+    try {
+        const schedule: unknown = await request.json();
+        if (!isValidSchedule(schedule)) {
+            return NextResponse.json(
+                { error: "Each start and end time must be valid, and end must be after start." },
+                { status: 400 }
+            );
+        }
+
+        await putSchoolSchedule(schedule);
+        return NextResponse.json(schedule);
+    } catch (error) {
+        console.error("Failed to save school schedule:", error);
+        return NextResponse.json({ error: "Failed to save school schedule" }, { status: 500 });
+    }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,15 @@
+import ScheduleSettingsForm from "@/components/ScheduleSettingsForm";
+import requireAdmin from "@/utils/auth";
+
+export default async function SettingsPage() {
+    await requireAdmin();
+
+    return (
+        <main className="mx-auto max-w-6xl p-5 sm:p-8">
+            <p className="text-sm font-black uppercase tracking-[0.18em] text-emerald-700">Administration</p>
+            <h1 className="mt-1 text-3xl font-black text-slate-900">School settings</h1>
+            <p className="mb-6 mt-2 text-slate-500">Set the expected day for accurate on-time attendance reporting.</p>
+            <ScheduleSettingsForm />
+        </main>
+    );
+}

--- a/src/components/DailyReport.tsx
+++ b/src/components/DailyReport.tsx
@@ -7,6 +7,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import DatePicker from "@/components/DatePicker";
 import AttendanceTable from "@/components/AttendanceTable";
 import DownloadCSVButton from "@/components/DownloadCsvButton";
+import { CheckCircle2, ClockAlert, Timer } from "lucide-react";
+import { DEFAULT_SCHOOL_SCHEDULE, scheduleGroupForUserType, SchoolSchedule } from "@/types/schedule";
 
 type BaseUser = {
     userId: string;
@@ -34,6 +36,7 @@ export default function DailyReport() {
     const [selectedDate, setSelectedDate] = useState<Date>(new Date());
     const [query, setQuery] = useState("");
     const [loading, setLoading] = useState(false);
+    const [schedule, setSchedule] = useState<SchoolSchedule>(DEFAULT_SCHOOL_SCHEDULE);
     const [userTypeFilter, setUserTypeFilter] = useState(() => {
         if (typeof window !== "undefined") {
             const savedType = localStorage.getItem(LOCAL_TYPE_STORAGE_KEY);
@@ -61,9 +64,15 @@ export default function DailyReport() {
             setLoading(true);
             try {
                 const formattedDate = format(selectedDate, 'yyyy-MM-dd');
-                const res = await fetch(`/api/reports/attendance?date=${formattedDate}&userType=${userTypeFilter}`);
-                const data = await res.json();
+                const [attendanceResponse, scheduleResponse] = await Promise.all([
+                    fetch(`/api/reports/attendance?date=${formattedDate}&userType=${userTypeFilter}`),
+                    fetch("/api/settings/schedule"),
+                ]);
+                const data = await attendanceResponse.json();
+                if (!attendanceResponse.ok) throw new Error(data.error ?? "Failed to load attendance");
                 setRecords(data);
+
+                if (scheduleResponse.ok) setSchedule(await scheduleResponse.json());
             } catch (err) {
                 console.error('Error fetching attendance:', err);
             } finally {
@@ -91,8 +100,52 @@ export default function DailyReport() {
                 new Date(b.dateTimeStamp).getTime()
         );
 
+    const dayWindow = schedule[scheduleGroupForUserType(userTypeFilter)];
+    const firstArrivalByUser = new Map<string, string>();
+    records
+        .filter((record) => record.state.toLowerCase() === "in" && record.user?.userId)
+        .sort((a, b) => a.dateTimeStamp.localeCompare(b.dateTimeStamp))
+        .forEach((record) => {
+            const userId = record.user!.userId;
+            if (!firstArrivalByUser.has(userId)) {
+                firstArrivalByUser.set(
+                    userId,
+                    new Intl.DateTimeFormat("en-CA", {
+                        timeZone: "America/Chicago",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        hourCycle: "h23",
+                    }).format(new Date(record.dateTimeStamp))
+                );
+            }
+        });
+    const onTimeCount = [...firstArrivalByUser.values()].filter((time) => time <= dayWindow.startTime).length;
+    const lateCount = firstArrivalByUser.size - onTimeCount;
+    const lastDepartureByUser = new Map<string, string>();
+    records
+        .filter((record) => record.state.toLowerCase() === "out" && record.user?.userId)
+        .sort((a, b) => a.dateTimeStamp.localeCompare(b.dateTimeStamp))
+        .forEach((record) => {
+            lastDepartureByUser.set(
+                record.user!.userId,
+                new Intl.DateTimeFormat("en-CA", {
+                    timeZone: "America/Chicago",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    hourCycle: "h23",
+                }).format(new Date(record.dateTimeStamp))
+            );
+        });
+    const onTimeDepartureCount = [...lastDepartureByUser.values()].filter((time) => time >= dayWindow.endTime).length;
+
     return (
         <div className="p-6 space-y-4">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <MetricChip icon={<CheckCircle2 className="h-5 w-5" />} label="On-time arrivals" value={onTimeCount} tone="emerald" />
+                <MetricChip icon={<ClockAlert className="h-5 w-5" />} label="Late arrivals" value={lateCount} tone="amber" />
+                <MetricChip icon={<CheckCircle2 className="h-5 w-5" />} label="On-time departures" value={onTimeDepartureCount} tone="emerald" />
+                <MetricChip icon={<Timer className="h-5 w-5" />} label="Expected day" value={`${dayWindow.startTime}–${dayWindow.endTime}`} tone="slate" />
+            </div>
             <div className="flex flex-wrap gap-3 items-center">
 
             </div>
@@ -190,6 +243,28 @@ export default function DailyReport() {
                         },
                     ]}
                 />
+            </div>
+        </div>
+    );
+}
+
+function MetricChip({ icon, label, value, tone }: {
+    icon: React.ReactNode;
+    label: string;
+    value: string | number;
+    tone: "emerald" | "amber" | "slate";
+}) {
+    const tones = {
+        emerald: "border-emerald-200 bg-emerald-50 text-emerald-800",
+        amber: "border-amber-200 bg-amber-50 text-amber-800",
+        slate: "border-slate-200 bg-slate-50 text-slate-700",
+    };
+    return (
+        <div className={`flex items-center gap-3 rounded-2xl border px-4 py-3 ${tones[tone]}`}>
+            {icon}
+            <div>
+                <p className="text-xs font-black uppercase tracking-wider opacity-75">{label}</p>
+                <p className="text-xl font-black">{value}</p>
             </div>
         </div>
     );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import LoginButton from "./LoginButton";
 import { useSession } from "next-auth/react";
 import Image from "next/image";
-import { BarChart3, Users } from "lucide-react";
+import { BarChart3, Settings, Users } from "lucide-react";
 import { useState } from "react";
 
 export default function Navbar() {
@@ -55,6 +55,9 @@ export default function Navbar() {
                         </Link>
                         <Link href="/reports" className="inline-flex min-h-10 items-center gap-2 rounded-lg px-3 text-sm font-bold hover:bg-slate-100 hover:text-slate-900">
                             <BarChart3 className="h-4 w-4" /> <span className="hidden md:inline">Reports</span>
+                        </Link>
+                        <Link href="/settings" className="inline-flex min-h-10 items-center gap-2 rounded-lg px-3 text-sm font-bold hover:bg-slate-100 hover:text-slate-900">
+                            <Settings className="h-4 w-4" /> <span className="hidden md:inline">Settings</span>
                         </Link>
                     </>
                 )}

--- a/src/components/ScheduleSettingsForm.tsx
+++ b/src/components/ScheduleSettingsForm.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Clock3, Save } from "lucide-react";
+import { DEFAULT_SCHOOL_SCHEDULE, SchoolSchedule } from "@/types/schedule";
+
+export default function ScheduleSettingsForm() {
+    const [schedule, setSchedule] = useState<SchoolSchedule>(DEFAULT_SCHOOL_SCHEDULE);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [message, setMessage] = useState("");
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        fetch("/api/settings/schedule")
+            .then(async (response) => {
+                const body = await response.json();
+                if (!response.ok) throw new Error(body.error ?? "Failed to load schedule");
+                setSchedule(body);
+            })
+            .catch((reason) => setError(reason instanceof Error ? reason.message : "Failed to load schedule"))
+            .finally(() => setLoading(false));
+    }, []);
+
+    const setTime = (group: keyof SchoolSchedule, field: "startTime" | "endTime", value: string) => {
+        setSchedule((current) => ({
+            ...current,
+            [group]: { ...current[group], [field]: value },
+        }));
+        setMessage("");
+        setError("");
+    };
+
+    const save = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setSaving(true);
+        setError("");
+        setMessage("");
+        try {
+            const response = await fetch("/api/settings/schedule", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(schedule),
+            });
+            const body = await response.json();
+            if (!response.ok) throw new Error(body.error ?? "Failed to save schedule");
+            setSchedule(body);
+            setMessage("School-day schedule saved.");
+        } catch (reason) {
+            setError(reason instanceof Error ? reason.message : "Failed to save schedule");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (loading) return <div className="surface-card p-6 text-slate-500">Loading schedule…</div>;
+
+    return (
+        <form onSubmit={save} className="surface-card max-w-3xl overflow-hidden">
+            <div className="border-b border-slate-100 bg-white px-6 py-5">
+                <div className="flex items-center gap-3">
+                    <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700">
+                        <Clock3 className="h-5 w-5" />
+                    </span>
+                    <div>
+                        <h2 className="text-xl font-black text-slate-900">Daily attendance windows</h2>
+                        <p className="text-sm text-slate-500">Times use the school timezone (America/Chicago).</p>
+                    </div>
+                </div>
+            </div>
+
+            <div className="space-y-6 p-6">
+                {(["student", "staff"] as const).map((group) => (
+                    <fieldset key={group} className="rounded-2xl border border-slate-200 p-5">
+                        <legend className="px-2 text-sm font-black uppercase tracking-wider text-slate-600">
+                            {group === "student" ? "Students" : "Staff & volunteers"}
+                        </legend>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <label className="text-sm font-bold text-slate-700">
+                                Day starts
+                                <input type="time" required value={schedule[group].startTime} onChange={(event) => setTime(group, "startTime", event.target.value)} className="mt-2 h-11 w-full rounded-xl border border-slate-300 px-3 text-base" />
+                            </label>
+                            <label className="text-sm font-bold text-slate-700">
+                                Day ends
+                                <input type="time" required value={schedule[group].endTime} onChange={(event) => setTime(group, "endTime", event.target.value)} className="mt-2 h-11 w-full rounded-xl border border-slate-300 px-3 text-base" />
+                            </label>
+                        </div>
+                    </fieldset>
+                ))}
+
+                {(error || message) && <div role="status" className={`rounded-xl px-4 py-3 text-sm font-bold ${error ? "bg-rose-50 text-rose-700" : "bg-emerald-50 text-emerald-700"}`}>{error || message}</div>}
+
+                <div className="flex justify-end">
+                    <button type="submit" disabled={saving} className="primary-action">
+                        <Save className="h-5 w-5" /> {saving ? "Saving…" : "Save schedule"}
+                    </button>
+                </div>
+            </div>
+        </form>
+    );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,9 @@ const isAdminRoute = (pathname: string) =>
     pathname === "/users" ||
     pathname.startsWith("/users/") ||
     pathname === "/reports" ||
-    pathname.startsWith("/reports/");
+    pathname.startsWith("/reports/") ||
+    pathname === "/settings" ||
+    pathname.startsWith("/settings/");
 
 export default withAuth({
     callbacks: {

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,17 @@
+export type DayWindow = {
+    startTime: string;
+    endTime: string;
+};
+
+export type SchoolSchedule = {
+    student: DayWindow;
+    staff: DayWindow;
+};
+
+export const DEFAULT_SCHOOL_SCHEDULE: SchoolSchedule = {
+    student: { startTime: "08:30", endTime: "15:00" },
+    staff: { startTime: "08:00", endTime: "16:00" },
+};
+
+export const scheduleGroupForUserType = (userType: string): keyof SchoolSchedule =>
+    userType.toLowerCase() === "learner" ? "student" : "staff";

--- a/src/utils/dynamo.ts
+++ b/src/utils/dynamo.ts
@@ -15,11 +15,13 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import { isGuardian, BaseUser, GuardianUser, RegularUser, User } from "@/types/user";
 import { TimeAttendanceRecord, RawTimeAttendanceItem} from "@/types/attendance";
+import { DEFAULT_SCHOOL_SCHEDULE, SchoolSchedule } from "@/types/schedule";
 import { enumerateMonths } from "@/utils/attendance";
 
 export const client = new DynamoDBClient({ region: process.env.AWS_REGION });
 export const USERS_TABLE = `clockinclick-${process.env.SCHOOL_NAME}-Users` || "users";
 export const TIME_ATTENDANCE_TABLE = `clockinclick-${process.env.SCHOOL_NAME}-TimeAttendance`;
+export const SETTINGS_TABLE = `clockinclick-${process.env.SCHOOL_NAME}-Settings`;
 
 
 // ---------- Helpers ----------
@@ -557,3 +559,39 @@ export function unmarshallTimeAttendance(
         clockedBy: item.ClockedBy.S ?? "",
     };
 }
+
+const SCHEDULE_SETTING_ID = "school-day-schedule";
+
+export const getSchoolSchedule = async (): Promise<SchoolSchedule> => {
+    const result = await client.send(new GetItemCommand({
+        TableName: SETTINGS_TABLE,
+        Key: { SettingId: { S: SCHEDULE_SETTING_ID } },
+    }));
+
+    if (!result.Item) return DEFAULT_SCHOOL_SCHEDULE;
+
+    return {
+        student: {
+            startTime: getString(result.Item.StudentStartTime) ?? DEFAULT_SCHOOL_SCHEDULE.student.startTime,
+            endTime: getString(result.Item.StudentEndTime) ?? DEFAULT_SCHOOL_SCHEDULE.student.endTime,
+        },
+        staff: {
+            startTime: getString(result.Item.StaffStartTime) ?? DEFAULT_SCHOOL_SCHEDULE.staff.startTime,
+            endTime: getString(result.Item.StaffEndTime) ?? DEFAULT_SCHOOL_SCHEDULE.staff.endTime,
+        },
+    };
+};
+
+export const putSchoolSchedule = async (schedule: SchoolSchedule): Promise<void> => {
+    await client.send(new PutItemCommand({
+        TableName: SETTINGS_TABLE,
+        Item: {
+            SettingId: { S: SCHEDULE_SETTING_ID },
+            StudentStartTime: { S: schedule.student.startTime },
+            StudentEndTime: { S: schedule.student.endTime },
+            StaffStartTime: { S: schedule.staff.startTime },
+            StaffEndTime: { S: schedule.staff.endTime },
+            UpdatedAt: { S: new Date().toISOString() },
+        },
+    }));
+};

--- a/terraform/modules/school/dynamodb.tf
+++ b/terraform/modules/school/dynamodb.tf
@@ -101,3 +101,26 @@ resource "aws_dynamodb_table" "time_attendance" {
     application = var.project_name
   }
 }
+
+# Per-school operational settings, such as staff and student day schedules.
+resource "aws_dynamodb_table" "settings" {
+  name         = "${var.project_name}-${var.school_id}-Settings"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "SettingId"
+
+  deletion_protection_enabled = true
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "SettingId"
+    type = "S"
+  }
+
+  tags = {
+    client      = var.school_id
+    application = var.project_name
+  }
+}

--- a/terraform/modules/school/iam.tf
+++ b/terraform/modules/school/iam.tf
@@ -58,7 +58,11 @@ resource "aws_iam_role_policy" "amplify_compute" {
         "dynamodb:BatchGetItem", "dynamodb:DeleteItem", "dynamodb:GetItem",
         "dynamodb:PutItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:UpdateItem"
       ]
-      Resource = ["${aws_dynamodb_table.users.arn}*", "${aws_dynamodb_table.time_attendance.arn}*"]
+      Resource = [
+        "${aws_dynamodb_table.users.arn}*",
+        "${aws_dynamodb_table.time_attendance.arn}*",
+        "${aws_dynamodb_table.settings.arn}*",
+      ]
     }]
   })
 }

--- a/terraform/modules/school/outputs.tf
+++ b/terraform/modules/school/outputs.tf
@@ -6,6 +6,10 @@ output "time_attendance_table_name" {
   value = aws_dynamodb_table.time_attendance.name
 }
 
+output "settings_table_name" {
+  value = aws_dynamodb_table.settings.name
+}
+
 output "amplify_url" {
   value = "https://${var.repository_branch}.${aws_amplify_app.app.default_domain}"
 }


### PR DESCRIPTION
## What changed

- adds protected school schedule settings for student and staff/volunteer start and end times
- persists each school's schedule in a dedicated DynamoDB settings table
- grants the Amplify compute role access to the new table
- adds real daily on-time arrival, late arrival, and on-time departure metrics
- adds Settings navigation and protects the page and API with existing admin access controls

## Behavior

- the first IN punch determines whether an arrival is on time
- the final OUT punch determines whether a departure meets the configured end time
- learner punches use the student schedule; staff and volunteer punches use the staff schedule
- calculations use the existing America/Chicago school timezone

## Validation

- npm run lint
- npm run build
- git diff --check