### PR TITLE
Add resettable public demo school

### DIFF
--- a/.github/workflows/reset-demo.yml
+++ b/.github/workflows/reset-demo.yml
@@ -1,0 +1,21 @@
+name: Reset demo school
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  reset:
+    runs-on: ubuntu-latest
+    environment: Prod
+    steps:
+      - name: Restore demo data
+        env:
+          DEMO_RESET_TOKEN: ${{ secrets.DEMO_RESET_TOKEN }}
+        run: |
+          curl --fail --show-error --silent \
+            --retry 3 \
+            --request POST \
+            --header "Authorization: Bearer ${DEMO_RESET_TOKEN}" \
+            https://demo.clockin.click/api/demo/reset

--- a/scripts/write-amplify-env.mjs
+++ b/scripts/write-amplify-env.mjs
@@ -4,14 +4,17 @@ const secretFile = process.argv[2];
 if (!secretFile) throw new Error("Expected the Secrets Manager JSON file path");
 
 const secrets = JSON.parse(readFileSync(secretFile, "utf8"));
+const isDemo = process.env.SCHOOL_NAME?.toLowerCase() === "demo";
 const runtime = {
     ...secrets,
     SCHOOL_NAME: process.env.SCHOOL_NAME,
     NEXT_PUBLIC_SCHOOL_NAME: process.env.SCHOOL_NAME,
+    DEMO_MODE: String(isDemo),
+    NEXT_PUBLIC_DEMO_MODE: String(isDemo),
     ...(existsSync("public/images/school-logo.png")
         ? { NEXT_PUBLIC_SCHOOL_LOGO: "/images/school-logo.png" }
         : {}),
-    NEXTAUTH_URL: `https://${process.env.SCHOOL_NAME}.clockin.click`,
+    NEXTAUTH_URL: `https://${process.env.SCHOOL_NAME.toLowerCase()}.clockin.click`,
 };
 
 const contents = Object.entries(runtime)

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,9 @@
 import NextAuth, {AuthOptions} from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
+import CredentialsProvider from "next-auth/providers/credentials";
 import {getAdminLevel} from "@/utils/dynamo";
+
+const isDemo = process.env.DEMO_MODE === "true";
 
 export const authOptions: AuthOptions = {
     providers: [
@@ -8,9 +11,18 @@ export const authOptions: AuthOptions = {
             clientId: process.env.GOOGLE_CLIENT_ID!,
             clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
         }),
+        ...(isDemo ? [CredentialsProvider({
+            id: "demo",
+            name: "Demo administrator",
+            credentials: {},
+            async authorize() {
+                return { id: "demo-admin", name: "Demo Administrator", email: "demo@clockin.click" };
+            },
+        })] : []),
     ],
     callbacks: {
-        async signIn({ user }) {
+        async signIn({ user, account }) {
+            if (isDemo && account?.provider === "demo") return true;
             if (!user?.email) {
                 console.warn("Sign in failed: no email provided");
                 return false; // must return boolean, not null
@@ -26,8 +38,16 @@ export const authOptions: AuthOptions = {
 
             return true; // allow login
         },
-        async session({ session }) {
-            // optional: add isAdmin flag to session
+        async jwt({ token, account }) {
+            if (isDemo && account?.provider === "demo") token.demoAdmin = true;
+            return token;
+        },
+        async session({ session, token }) {
+            if (isDemo && token.demoAdmin) {
+                session.user.isAdmin = true;
+                session.user.adminLevel = "edit";
+                return session;
+            }
             session.user.isAdmin = true;
             session.user.adminLevel = session.user.email ? await getAdminLevel(session.user.email) : null;
             return session;

--- a/src/app/api/demo/reset/route.ts
+++ b/src/app/api/demo/reset/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { resetDemoData } from "@/utils/demoData";
+
+export async function POST(request: Request) {
+    if (process.env.DEMO_MODE !== "true") {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const expected = process.env.DEMO_RESET_TOKEN;
+    const supplied = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+    if (!expected || supplied !== expected) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        return NextResponse.json(await resetDemoData());
+    } catch (error) {
+        console.error("Demo reset failed:", error);
+        return NextResponse.json({ error: "Demo reset failed" }, { status: 500 });
+    }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ type ClockAction = { userId: string; status: "In" | "Out" };
 
 export default function PinEntry() {
     const schoolName = process.env.NEXT_PUBLIC_SCHOOL_NAME || "Your school";
+    const isDemo = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
     const [pin, setPin] = useState("");
     const [user, setUser] = useState<KioskUser | null>(null);
     const [error, setError] = useState("");
@@ -100,6 +101,12 @@ export default function PinEntry() {
     return (
         <div className="kiosk-shell min-h-[calc(100vh-5rem)] px-4 py-8 sm:px-6 sm:py-12">
             <div className="mx-auto max-w-3xl">
+                {isDemo && !user && (
+                    <div className="mb-6 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-950 shadow-sm">
+                        <p className="font-black">Interactive demo school</p>
+                        <p className="mt-1">Try guardian PIN <strong>2468</strong> or staff PIN <strong>1357</strong>. Use <strong>Explore admin</strong> above for reports, people, and settings. Demo data resets nightly.</p>
+                    </div>
+                )}
                 {!user ? (
                     <div className="grid items-center gap-8 lg:grid-cols-[1fr_25rem]">
                         <section className="hidden lg:block">

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -5,6 +5,7 @@ import { LogIn, LogOut } from "lucide-react";
 
 export default function LoginButton() {
     const { data: session } = useSession();
+    const isDemo = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
 
     if (session) {
         return (
@@ -21,10 +22,10 @@ export default function LoginButton() {
     }
     return (
         <button
-            onClick={() => signIn("google")}
+            onClick={() => signIn(isDemo ? "demo" : "google")}
             className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-slate-200 px-3 text-sm font-bold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
         >
-           <LogIn className="h-4 w-4" /> <span className="hidden sm:inline">Admin sign in</span>
+           <LogIn className="h-4 w-4" /> <span className="hidden sm:inline">{isDemo ? "Explore admin" : "Admin sign in"}</span>
         </button>
     );
 }

--- a/src/utils/demoData.ts
+++ b/src/utils/demoData.ts
@@ -1,0 +1,108 @@
+import { DeleteItemCommand, PutItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { format } from "date-fns";
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
+import {
+    client,
+    marshallUser,
+    putSchoolSchedule,
+    SETTINGS_TABLE,
+    TIME_ATTENDANCE_TABLE,
+    USERS_TABLE,
+} from "@/utils/dynamo";
+import type { User } from "@/types/user";
+import { TIME_ZONE } from "@/utils/attendance";
+
+const DEMO_USERS: User[] = [
+    {
+        userId: "demo-guardian-rivera",
+        firstName: "Jordan",
+        lastName: "Rivera",
+        roles: ["guardian"],
+        pin: "2468",
+        learners: [
+            { userId: "demo-learner-maya", firstName: "Maya", lastName: "Rivera", roles: ["learner"], pin: "" },
+            { userId: "demo-learner-theo", firstName: "Theo", lastName: "Rivera", roles: ["learner"], pin: "" },
+        ],
+    },
+    { userId: "demo-learner-maya", firstName: "Maya", lastName: "Rivera", roles: ["learner"], pin: "", status: "Out" },
+    { userId: "demo-learner-theo", firstName: "Theo", lastName: "Rivera", roles: ["learner"], pin: "", status: "Out" },
+    { userId: "demo-learner-avery", firstName: "Avery", lastName: "Chen", roles: ["learner"], pin: "", status: "Out" },
+    { userId: "demo-staff-morgan", firstName: "Alex", lastName: "Morgan", roles: ["staff"], pin: "1357", status: "Out" },
+    { userId: "demo-staff-patel", firstName: "Sam", lastName: "Patel", roles: ["staff"], pin: "8642", status: "Out" },
+    { userId: "demo-volunteer-brooks", firstName: "Taylor", lastName: "Brooks", roles: ["volunteer"], pin: "9753", status: "Out" },
+];
+
+const deleteAll = async (tableName: string, keyNames: string[]) => {
+    let exclusiveStartKey: Record<string, import("@aws-sdk/client-dynamodb").AttributeValue> | undefined;
+    do {
+        const page = await client.send(new ScanCommand({ TableName: tableName, ExclusiveStartKey: exclusiveStartKey }));
+        await Promise.all((page.Items ?? []).map((item) =>
+            client.send(new DeleteItemCommand({
+                TableName: tableName,
+                Key: Object.fromEntries(keyNames.map((key) => [key, item[key]])),
+            }))
+        ));
+        exclusiveStartKey = page.LastEvaluatedKey;
+    } while (exclusiveStartKey);
+};
+
+const demoDays = () => {
+    const days: string[] = [];
+    const cursor = toZonedTime(new Date(), TIME_ZONE);
+    while (days.length < 5) {
+        const local = format(cursor, "yyyy-MM-dd");
+        const weekday = cursor.getDay();
+        if (weekday !== 0 && weekday !== 6) days.unshift(local);
+        cursor.setDate(cursor.getDate() - 1);
+    }
+    return days;
+};
+
+const attendanceItem = (userId: string, userType: string, day: string, time: string, state: "In" | "Out") => {
+    const timestamp = fromZonedTime(`${day}T${time}:00`, TIME_ZONE).toISOString();
+    return {
+        UserTypeYearMonth: { S: `${userType}#${timestamp.slice(0, 7)}` },
+        DateTimeStamp: { S: timestamp },
+        UserId: { S: userId },
+        State: { S: state },
+        ClockedBy: { S: userType === "learner" ? "demo-guardian-rivera" : userId },
+        Id: { S: crypto.randomUUID() },
+    };
+};
+
+export const resetDemoData = async () => {
+    if (process.env.DEMO_MODE !== "true") throw new Error("Demo reset is disabled for this tenant");
+
+    await Promise.all([
+        deleteAll(USERS_TABLE, ["UserId"]),
+        deleteAll(TIME_ATTENDANCE_TABLE, ["UserTypeYearMonth", "DateTimeStamp"]),
+        deleteAll(SETTINGS_TABLE, ["SettingId"]),
+    ]);
+
+    await Promise.all(DEMO_USERS.map((user) => client.send(new PutItemCommand({
+        TableName: USERS_TABLE,
+        Item: marshallUser(user),
+    }))));
+
+    await putSchoolSchedule({
+        student: { startTime: "08:30", endTime: "15:00" },
+        staff: { startTime: "08:00", endTime: "16:00" },
+    });
+
+    const punches = demoDays().flatMap((day, index) => [
+        attendanceItem("demo-learner-maya", "learner", day, index % 3 === 0 ? "08:38" : "08:18", "In"),
+        attendanceItem("demo-learner-maya", "learner", day, "15:08", "Out"),
+        attendanceItem("demo-learner-theo", "learner", day, "08:24", "In"),
+        attendanceItem("demo-learner-theo", "learner", day, index === 2 ? "14:40" : "15:05", "Out"),
+        attendanceItem("demo-learner-avery", "learner", day, index % 2 ? "08:35" : "08:12", "In"),
+        attendanceItem("demo-learner-avery", "learner", day, "15:02", "Out"),
+        attendanceItem("demo-staff-morgan", "staff", day, "07:48", "In"),
+        attendanceItem("demo-staff-morgan", "staff", day, "16:12", "Out"),
+        attendanceItem("demo-staff-patel", "staff", day, index === 1 ? "08:09" : "07:55", "In"),
+        attendanceItem("demo-staff-patel", "staff", day, "16:04", "Out"),
+    ]);
+
+    await Promise.all(punches.map((Item) => client.send(new PutItemCommand({ TableName: TIME_ATTENDANCE_TABLE, Item }))));
+
+    return { users: DEMO_USERS.length, punches: punches.length, resetAt: new Date().toISOString() };
+};

--- a/terraform/DEMO_SCHOOL.md
+++ b/terraform/DEMO_SCHOOL.md
@@ -1,0 +1,16 @@
+# Demo school
+
+Terraform always provisions a `Demo` tenant in addition to the schools supplied through the `SCHOOLS` repository variable. Its public URL is `https://demo.clockin.click`.
+
+The demo tenant enables a one-click administrator session and displays sample kiosk PINs. These behaviors are gated by build-time `DEMO_MODE`; customer tenants continue to use Google authentication.
+
+## Reset configuration
+
+Generate a long random value and store the same value in both locations:
+
+1. Add `DEMO_RESET_TOKEN` to the JSON object in the `clockinclick-app-secrets` AWS Secrets Manager secret.
+2. Add `DEMO_RESET_TOKEN` to the GitHub `Prod` environment used by this repository.
+
+The `Reset demo school` workflow calls the demo-only reset endpoint every day at 08:00 UTC and can also be run manually. Run it manually once after the first infrastructure deployment to create the fictional users, attendance history, and default schedules.
+
+The endpoint returns 404 outside the demo tenant and requires the reset token on the demo tenant. It deletes and recreates data only in tables derived from `SCHOOL_NAME=Demo`.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,9 @@
+locals {
+  school_ids = distinct(concat(var.schools, [var.demo_school_name]))
+}
+
 module "schools" {
-  for_each            = toset(var.schools)
+  for_each            = toset(local.school_ids)
   source              = "./modules/school"
   school_id           = each.value
   project_name        = var.project_name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,12 @@ variable "schools" {
   default = ["test"]
 }
 
+variable "demo_school_name" {
+  type        = string
+  description = "Public demo tenant that is always provisioned alongside customer schools."
+  default     = "Demo"
+}
+
 variable "repository_url" {
   type    = string
   default = "https://github.com/kottok-technologies/clockin.click"


### PR DESCRIPTION
## What changed

- always provisions an isolated Demo tenant alongside configured customer schools
- enables one-click full administrator access only when DEMO_MODE is active
- displays safe sample kiosk PINs on the demo landing page
- adds fictional users, attendance history, and schedule seed data
- adds a token-protected demo-only reset endpoint
- resets demo data nightly and supports manual reset through GitHub Actions
- documents the required shared reset token configuration

## Safety

Customer tenants retain Google authentication. The reset endpoint returns 404 outside the Demo tenant, requires a bearer token, and derives all target tables from SCHOOL_NAME=Demo.

## Setup after merge

1. Add the same DEMO_RESET_TOKEN value to the AWS app-secret JSON and GitHub Prod environment.
2. Deploy Terraform to create demo.clockin.click and its tables.
3. Run the Reset demo school workflow once to create the initial sample data.

## Validation

- npm run lint
- npm run build
- git diff --check