### PR TITLE
Clean up attendance reports

### DIFF
--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -2,12 +2,6 @@
 
 import React, { useState } from 'react';
 import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
-import {
     BarChart3,
     CalendarDays,
     CalendarRange,
@@ -21,46 +15,40 @@ import YearlyReport from "@/components/YearlyReport";
 
 type Tab = 'daily' | 'weekly' | 'monthly' | 'yearly';
 
-const TITLES: Record<Tab, { icon: React.ReactNode; label: string }> = {
-    daily: { icon: <Table className="w-5 h-5" />, label: 'Daily attendance' },
-    weekly: { icon: <BarChart3 className="w-5 h-5" />, label: 'Weekly Summary' },
-    monthly: { icon: <CalendarDays className="w-5 h-5" />, label: 'Monthly Summary' },
-    yearly: { icon: <CalendarRange className="w-5 h-5" />, label: 'Yearly Summary' },
+const TITLES: Record<Tab, { icon: React.ReactNode; label: string; description: string }> = {
+    daily: { icon: <Table className="h-5 w-5" />, label: 'Daily activity', description: 'Review individual arrivals and departures for one day.' },
+    weekly: { icon: <BarChart3 className="h-5 w-5" />, label: 'Weekly overview', description: 'Spot complete and incomplete attendance days across the school.' },
+    monthly: { icon: <CalendarDays className="h-5 w-5" />, label: 'Monthly detail', description: 'Compare presence or hours for every recorded school day.' },
+    yearly: { icon: <CalendarRange className="h-5 w-5" />, label: 'Yearly trends', description: 'See attendance totals and patterns month by month.' },
 };
 
 export default function AttendanceReportPage() {
     const [activeTab, setActiveTab] = useState<Tab>('daily');
 
     return (
-        <main className="p-5 sm:p-8 max-w-6xl mx-auto space-y-6">
+        <main className="mx-auto max-w-7xl space-y-6 p-5 sm:p-8">
             <div>
                 <p className="text-sm font-black uppercase tracking-[0.18em] text-emerald-700">Insights</p>
                 <h1 className="mt-1 text-3xl font-black text-slate-900">Attendance</h1>
                 <p className="mt-2 text-slate-500">Understand attendance patterns across your school community.</p>
             </div>
-            <Card className="shadow-lg">
-                <CardHeader>
-                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                        <CardTitle className="text-2xl font-semibold flex items-center gap-2">
-                            {TITLES[activeTab].icon} {TITLES[activeTab].label}
-                        </CardTitle>
-                    </div>
-                </CardHeader>
-
-                <CardContent className="space-y-4">
+            <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+                <div className="border-b border-slate-200 p-4 sm:p-6">
                     <Tabs
                         value={activeTab}
                         onValueChange={(v) => setActiveTab(v as Tab)}
                         className="w-full"
                     >
-                        <TabsList className="mb-4">
+                        <TabsList className="mb-6 grid h-auto w-full grid-cols-2 gap-1 rounded-xl bg-slate-100 p-1 lg:grid-cols-4">
                             <TabsTrigger value="daily">Daily</TabsTrigger>
                             <TabsTrigger value="weekly">Weekly</TabsTrigger>
                             <TabsTrigger value="monthly">Monthly</TabsTrigger>
                             <TabsTrigger value="yearly">Yearly</TabsTrigger>
                         </TabsList>
 
-                        <TabsContent value="daily" className="space-y-4">
+                        <div className="mb-5 flex items-start gap-3"><div className="rounded-xl bg-emerald-50 p-2.5 text-emerald-700">{TITLES[activeTab].icon}</div><div><h2 className="text-xl font-black text-slate-900">{TITLES[activeTab].label}</h2><p className="mt-1 text-sm text-slate-500">{TITLES[activeTab].description}</p></div></div>
+
+                        <TabsContent value="daily">
                             <DailyReport />
                         </TabsContent>
 
@@ -76,8 +64,8 @@ export default function AttendanceReportPage() {
                             <YearlyReport />
                         </TabsContent>
                     </Tabs>
-                </CardContent>
-            </Card>
+                </div>
+            </section>
         </main>
     );
 }

--- a/src/components/AttendanceTable.tsx
+++ b/src/components/AttendanceTable.tsx
@@ -1,15 +1,8 @@
 import React from "react";
-import {
-    Table,
-    TableHeader,
-    TableHead,
-    TableBody,
-    TableRow,
-    TableCell,
-} from "@/components/ui/table";
+import { Table, TableHeader, TableHead, TableBody, TableRow, TableCell } from "@/components/ui/table";
 
 export type Column<T> = {
-    key: string; // instead of keyof T
+    key: string;
     label: string;
     render?: (item: T) => React.ReactNode;
     className?: string;
@@ -21,57 +14,42 @@ interface AttendanceTableProps<T> {
     data: T[];
     loading?: boolean;
     emptyMessage?: string;
+    getRowKey?: (item: T, index: number) => React.Key;
 }
 
 export default function AttendanceTable<T>({
-                                               columns,
-                                               data,
-                                               loading = false,
-                                               emptyMessage = "No attendance has been recorded yet.",
-                                           }: AttendanceTableProps<T>) {
+    columns,
+    data,
+    loading = false,
+    emptyMessage = "No attendance has been recorded yet.",
+    getRowKey,
+}: AttendanceTableProps<T>) {
     return (
-        <div className="overflow-x-auto border rounded-lg">
+        <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white">
             <Table>
                 <TableHeader>
                     <TableRow>
-                        {columns.map((col) => (
-                            <TableHead
-                                key={String(col.key)}
-                                title={col.headerTitle} // <-- show tooltip on header
-                                className={col.className}
-                            >
-                                {col.label}
+                        {columns.map((column) => (
+                            <TableHead key={column.key} title={column.headerTitle} className={`whitespace-nowrap bg-slate-50 text-xs font-black uppercase tracking-wider text-slate-500 ${column.className ?? ""}`}>
+                                {column.label}
                             </TableHead>
                         ))}
                     </TableRow>
                 </TableHeader>
-
                 <TableBody>
                     {loading ? (
-                        <TableRow>
-                            <TableCell colSpan={columns.length} className="text-center py-4 text-gray-500">
-                                Gathering attendance…
-                            </TableCell>
-                        </TableRow>
+                        <TableRow><TableCell colSpan={columns.length} className="py-14 text-center font-semibold text-slate-500">Gathering attendance…</TableCell></TableRow>
                     ) : data.length === 0 ? (
-                        <TableRow>
-                            <TableCell colSpan={columns.length} className="text-center py-4 text-gray-500">
-                                {emptyMessage}
-                            </TableCell>
+                        <TableRow><TableCell colSpan={columns.length} className="py-14 text-center text-slate-500">{emptyMessage}</TableCell></TableRow>
+                    ) : data.map((item, index) => (
+                        <TableRow key={getRowKey?.(item, index) ?? index} className="hover:bg-slate-50/70">
+                            {columns.map((column) => (
+                                <TableCell key={column.key} className={column.className ?? "text-center"}>
+                                    {column.render ? column.render(item) : String((item as Record<string, unknown>)[column.key] ?? "")}
+                                </TableCell>
+                            ))}
                         </TableRow>
-                    ) : (
-                        data.map((item, idx) => (
-                            <TableRow key={idx}>
-                                {columns.map((col) => (
-                                    <TableCell key={String(col.key)} className={col.className ?? "text-center"}>
-                                        {typeof col.render === "function"
-                                            ? col.render(item)
-                                            : String((item as Record<string, unknown>)[col.key] ?? "")}
-                                    </TableCell>
-                                ))}
-                            </TableRow>
-                        ))
-                    )}
+                    ))}
                 </TableBody>
             </Table>
         </div>

--- a/src/components/DailyReport.tsx
+++ b/src/components/DailyReport.tsx
@@ -9,6 +9,7 @@ import AttendanceTable from "@/components/AttendanceTable";
 import DownloadCSVButton from "@/components/DownloadCsvButton";
 import { CheckCircle2, ClockAlert, Timer } from "lucide-react";
 import { DEFAULT_SCHOOL_SCHEDULE, scheduleGroupForUserType, SchoolSchedule } from "@/types/schedule";
+import { ReportError, ReportToolbar } from "@/components/ReportChrome";
 
 type BaseUser = {
     userId: string;
@@ -36,6 +37,7 @@ export default function DailyReport() {
     const [selectedDate, setSelectedDate] = useState<Date>(new Date());
     const [query, setQuery] = useState("");
     const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
     const [schedule, setSchedule] = useState<SchoolSchedule>(DEFAULT_SCHOOL_SCHEDULE);
     const [userTypeFilter, setUserTypeFilter] = useState(() => {
         if (typeof window !== "undefined") {
@@ -62,6 +64,7 @@ export default function DailyReport() {
     useEffect(() => {
         const fetchRecords = async () => {
             setLoading(true);
+            setError(null);
             try {
                 const formattedDate = format(selectedDate, 'yyyy-MM-dd');
                 const [attendanceResponse, scheduleResponse] = await Promise.all([
@@ -75,6 +78,8 @@ export default function DailyReport() {
                 if (scheduleResponse.ok) setSchedule(await scheduleResponse.json());
             } catch (err) {
                 console.error('Error fetching attendance:', err);
+                setRecords([]);
+                setError(err instanceof Error ? err.message : "Failed to load attendance.");
             } finally {
                 setLoading(false);
             }
@@ -139,17 +144,14 @@ export default function DailyReport() {
     const onTimeDepartureCount = [...lastDepartureByUser.values()].filter((time) => time >= dayWindow.endTime).length;
 
     return (
-        <div className="p-6 space-y-4">
+        <div className="space-y-5">
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
                 <MetricChip icon={<CheckCircle2 className="h-5 w-5" />} label="On-time arrivals" value={onTimeCount} tone="emerald" />
                 <MetricChip icon={<ClockAlert className="h-5 w-5" />} label="Late arrivals" value={lateCount} tone="amber" />
                 <MetricChip icon={<CheckCircle2 className="h-5 w-5" />} label="On-time departures" value={onTimeDepartureCount} tone="emerald" />
                 <MetricChip icon={<Timer className="h-5 w-5" />} label="Expected day" value={`${dayWindow.startTime}–${dayWindow.endTime}`} tone="slate" />
             </div>
-            <div className="flex flex-wrap gap-3 items-center">
-
-            </div>
-            <div className="flex items-center gap-3">
+            <ReportToolbar>
                 <div className="flex items-center gap-2">
                     <DatePicker
                         selectedDate={selectedDate}
@@ -161,21 +163,21 @@ export default function DailyReport() {
                     value={userTypeFilter}
                     onValueChange={setUserTypeFilter}
                 >
-                    <SelectTrigger className="w-40">
+                    <SelectTrigger className="w-full sm:w-44">
                         <SelectValue placeholder="Filter by type" />
                     </SelectTrigger>
                     <SelectContent>
                         <SelectItem value="staff">Staff</SelectItem>
-                        <SelectItem value="learner">Learner</SelectItem>
+                        <SelectItem value="learner">Students</SelectItem>
                         <SelectItem value="volunteer">Volunteer</SelectItem>
                     </SelectContent>
                 </Select>
 
                 <Input
-                    placeholder="Search name..."
+                    placeholder="Search people..."
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
-                    className="w-60"
+                    className="w-full sm:w-60"
                 />
                 <DownloadCSVButton
                     columns={['User', 'State', 'Clocked By', 'DateTimeStamp', 'User Type']}
@@ -187,12 +189,13 @@ export default function DailyReport() {
                         userTypeFilter,
                     ])}
                     fileName={`attendance-${format(selectedDate, "yyyy-MM-dd")}.csv`}
-                    className="flex items-center gap-2"
+                    className="sm:ml-auto"
+                    disabled={loading || filtered.length === 0}
                 />
 
-            </div>
+            </ReportToolbar>
 
-            <div className="overflow-x-auto border rounded-lg">
+            {error && <ReportError message={error} />}
 
                 <AttendanceTable
                     data={filtered}
@@ -242,8 +245,9 @@ export default function DailyReport() {
                             render: (r) => format(new Date(r.dateTimeStamp), "PPpp"),
                         },
                     ]}
+                    emptyMessage="No attendance was recorded for this day and group."
+                    getRowKey={(record) => `${record.user?.userId ?? "unknown"}-${record.dateTimeStamp}`}
                 />
-            </div>
         </div>
     );
 }

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -47,12 +47,12 @@ export default function DatePicker({ selectedDate, setSelectedDate }: DatePicker
     }, []);
 
     return (
-        <div ref={containerRef} className="relative inline-block">
+        <div ref={containerRef} className="relative w-full sm:w-auto">
             {/* Trigger Button */}
             <Button
                 variant="outline"
                 onClick={() => setShowCalendar((prev) => !prev)}
-                className="w-48 justify-start text-left font-normal whitespace-nowrap"
+                className="w-full justify-start whitespace-nowrap text-left font-normal sm:w-48"
             >
                 {selectedDate ? format(selectedDate, "PPP") : "Pick a date"}
             </Button>

--- a/src/components/DownloadCsvButton.tsx
+++ b/src/components/DownloadCsvButton.tsx
@@ -10,6 +10,7 @@ interface DownloadCSVButtonProps {
     fileName?: string;
     className?: string;
     onClick?: () => void;
+    disabled?: boolean;
 }
 
 export default function DownloadCSVButton({
@@ -18,6 +19,7 @@ export default function DownloadCSVButton({
                                               fileName = "export.csv",
                                               className,
                                               onClick,
+                                              disabled = false,
                                           }: DownloadCSVButtonProps) {
     const handleDownload = () => {
         if (onClick) {
@@ -40,7 +42,7 @@ export default function DownloadCSVButton({
     };
 
     return (
-        <Button onClick={handleDownload} className={className}>
+        <Button variant="outline" disabled={disabled} onClick={handleDownload} className={className}>
             <Download className="w-4 h-4" /> Export CSV
         </Button>
     );

--- a/src/components/MonthlyReport.tsx
+++ b/src/components/MonthlyReport.tsx
@@ -15,6 +15,7 @@ import {
 import { useAttendanceSummary } from "@/hooks/useAttendanceSummary";
 import { SummaryRow } from "@/types/attendance";
 import { cn } from "@/lib/utils";
+import { ReportError, ReportMetric, ReportToolbar } from "@/components/ReportChrome";
 
 const REPORTED_ROLES = ["learner", "staff", "volunteer"];
 
@@ -153,8 +154,13 @@ export default function MonthlyReport() {
     const monthLabel = format(new Date(year, month, 1), "MMMM yyyy");
 
     return (
-        <div className="p-6 space-y-4">
-            <div className="flex flex-wrap items-center gap-3">
+        <div className="space-y-5">
+            <div className="grid gap-3 sm:grid-cols-3">
+                <ReportMetric label="School days" value={schoolDays.length} detail={monthLabel} />
+                <ReportMetric label="People recorded" value={rows.length} />
+                <ReportMetric label="Incomplete punches" value={rows.reduce((total, row) => total + row.totals.incompleteDays, 0)} tone="amber" />
+            </div>
+            <ReportToolbar>
                 <MonthPicker
                     year={year}
                     month={month}
@@ -175,25 +181,27 @@ export default function MonthlyReport() {
                     </SelectContent>
                 </Select>
 
-                <span className="text-gray-600">
-                    {monthLabel} &middot; {schoolDays.length} school days
+                <span className="text-sm font-bold text-slate-600">
+                    {monthLabel}
                 </span>
 
                 <DownloadCSVButton
                     columns={csvColumns}
                     rows={csvRows}
                     fileName={`MonthlyReport_${format(new Date(year, month, 1), "yyyy-MM")}.csv`}
-                    className="flex items-center gap-2 ml-auto"
+                    className="sm:ml-auto"
+                    disabled={loading || rows.length === 0}
                 />
-            </div>
+            </ReportToolbar>
 
-            {error && <p className="text-red-600">{error}</p>}
+            {error && <ReportError message={error} />}
 
             <AttendanceTable<SummaryRow>
                 data={rows}
                 columns={columns}
                 loading={loading}
                 emptyMessage="No attendance recorded for this month."
+                getRowKey={(row) => row.userId}
             />
         </div>
     );

--- a/src/components/ReportChrome.tsx
+++ b/src/components/ReportChrome.tsx
@@ -1,0 +1,24 @@
+import { AlertCircle } from "lucide-react";
+import React from "react";
+
+export function ReportToolbar({ children }: { children: React.ReactNode }) {
+    return <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 sm:flex-row sm:flex-wrap sm:items-center">{children}</div>;
+}
+
+export function ReportMetric({ label, value, detail, tone = "slate" }: {
+    label: string;
+    value: string | number;
+    detail?: string;
+    tone?: "slate" | "emerald" | "amber";
+}) {
+    const tones = {
+        slate: "border-slate-200 bg-white text-slate-900",
+        emerald: "border-emerald-200 bg-emerald-50 text-emerald-950",
+        amber: "border-amber-200 bg-amber-50 text-amber-950",
+    };
+    return <div className={`rounded-2xl border p-4 ${tones[tone]}`}><p className="text-xs font-black uppercase tracking-[0.12em] opacity-60">{label}</p><p className="mt-1 text-2xl font-black">{value}</p>{detail && <p className="mt-1 text-xs font-semibold opacity-60">{detail}</p>}</div>;
+}
+
+export function ReportError({ message }: { message: string }) {
+    return <div role="alert" className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-bold text-red-800"><AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />{message}</div>;
+}

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, {useState, useEffect, useMemo, useCallback} from "react";
+import React, {useState, useEffect, useMemo} from "react";
 import {
     format,
     startOfWeek,
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import DownloadCSVButton from "@/components/DownloadCsvButton";
 import {fromZonedTime, toZonedTime} from "date-fns-tz";
 import { TIME_ZONE } from "@/utils/attendance";
+import { ReportError, ReportMetric, ReportToolbar } from "@/components/ReportChrome";
 
 type BaseUser = {
     userId: string;
@@ -45,6 +46,7 @@ export default function WeeklyReport() {
     const [records, setRecords] = useState<AttendanceRecord[]>([]);
     const [users, setUsers] = useState<BaseUser[]>([]);
     const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
     // Memoize weekStart and weekEnd to avoid rerender loops
     const weekStart = useMemo(() => startOfWeek(selectedDate, { weekStartsOn: 0 }), [selectedDate]);
@@ -77,9 +79,11 @@ export default function WeeklyReport() {
             try {
                 const res = await fetch(`/api/users?roles=${reportedRoles.join(',')}`);
                 const data = await res.json();
+                if (!res.ok) throw new Error(data.error || "Failed to load people.");
                 setUsers(data);
             } catch (err) {
                 console.error("Error fetching users:", err);
+                setError(err instanceof Error ? err.message : "Failed to load people.");
             }
         })();
     }, [reportedRoles]);
@@ -88,6 +92,7 @@ export default function WeeklyReport() {
     useEffect(() => {
         const fetchRecords = async () => {
             setLoading(true);
+            setError(null);
             try {
                 const start = format(weekStart, "yyyy-MM-dd");
                 const end = format(weekEnd, "yyyy-MM-dd");
@@ -95,17 +100,17 @@ export default function WeeklyReport() {
                 const data = await res.json();
 
                 if (!res.ok) {
-                    console.error("API Error:", data.error || "Unknown error");
-                    return [];
+                    throw new Error(data.error || "Failed to load weekly attendance.");
                 }
 
                 if (!Array.isArray(data)) {
-                    console.error("Unexpected data shape:", data);
-                    return [];
+                    throw new Error("Attendance data could not be read.");
                 }
                 setRecords(data);
             } catch (err) {
                 console.error("Error fetching weekly attendance:", err);
+                setRecords([]);
+                setError(err instanceof Error ? err.message : "Failed to load weekly attendance.");
             } finally {
                 setLoading(false);
             }
@@ -206,46 +211,39 @@ export default function WeeklyReport() {
         ]);
     }, [userDayData]);
 
-    const handleDownloadCSV = useCallback(() => {
-        if (!csvRows.length) return;
-
-        const headers = ["Name", ...daysOfWeek.map((d) => format(d, "EEE MM/dd"))];
-
-        const csvContent = [headers, ...csvRows]
-            .map((row) => row.map((cell) => `"${cell ?? ""}"`).join(","))
-            .join("\n");
-
-        const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8" });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `WeeklyReport_${format(weekStart, "yyyy-MM-dd")}_to_${format(weekEnd, "yyyy-MM-dd")}.csv`;
-        a.click();
-        URL.revokeObjectURL(url);
-    }, [csvRows, daysOfWeek, weekStart, weekEnd]);
+    const completeDays = userDayData.flatMap(({ days }) => days).filter(({ status }) => status === "Present").length;
+    const partialDays = userDayData.flatMap(({ days }) => days).filter(({ status }) => status === "Partial").length;
 
 
     return (
-        <div className="p-6 space-y-4">
-            <div className="flex items-center gap-3">
+        <div className="space-y-5">
+            <div className="grid gap-3 sm:grid-cols-3">
+                <ReportMetric label="People" value={users.length} detail="Students, staff & volunteers" />
+                <ReportMetric label="Complete days" value={completeDays} tone="emerald" />
+                <ReportMetric label="Incomplete days" value={partialDays} tone="amber" />
+            </div>
+            <ReportToolbar>
                 <DatePicker selectedDate={selectedDate} setSelectedDate={setSelectedDate} />
-                <span className="text-gray-600">
-                    Week of {format(weekStart, "MMM d")} - {format(weekEnd, "MMM d, yyyy")}
+                <span className="text-sm font-bold text-slate-600">
+                    {format(weekStart, "MMM d")} – {format(weekEnd, "MMM d, yyyy")}
                 </span>
                 <DownloadCSVButton
                     columns={["Name", ...daysOfWeek.map((d) => format(d, "EEE MM/dd"))]}
                     rows={csvRows}
                     fileName={`WeeklyReport_${format(weekStart, "yyyy-MM-dd")}_to_${format(weekEnd, "yyyy-MM-dd")}.csv`}
-                    className="flex items-center gap-2"
-                    onClick={handleDownloadCSV}
+                    className="sm:ml-auto"
+                    disabled={loading || csvRows.length === 0}
                 />
-            </div>
+            </ReportToolbar>
+
+            {error && <ReportError message={error} />}
 
             <AttendanceTable<BaseUser>
                 data={users}
                 columns={columns}
                 loading={loading}
                 emptyMessage="No users found."
+                getRowKey={(user) => user.userId}
             />
         </div>
     );

--- a/src/components/YearlyReport.tsx
+++ b/src/components/YearlyReport.tsx
@@ -15,6 +15,7 @@ import {
 import { useAttendanceSummary } from "@/hooks/useAttendanceSummary";
 import { SummaryRow } from "@/types/attendance";
 import { cn } from "@/lib/utils";
+import { ReportError, ReportMetric, ReportToolbar } from "@/components/ReportChrome";
 
 const REPORTED_ROLES = ["learner", "staff", "volunteer"];
 
@@ -155,8 +156,13 @@ export default function YearlyReport() {
     ]);
 
     return (
-        <div className="p-6 space-y-4">
-            <div className="flex flex-wrap items-center gap-3">
+        <div className="space-y-5">
+            <div className="grid gap-3 sm:grid-cols-3">
+                <ReportMetric label="School days" value={totalSchoolDays} detail={String(year)} />
+                <ReportMetric label="People recorded" value={rows.length} />
+                <ReportMetric label="Incomplete punches" value={rows.reduce((total, row) => total + row.totals.incompleteDays, 0)} tone="amber" />
+            </div>
+            <ReportToolbar>
                 <YearPicker year={year} years={years} onChange={setYear} />
 
                 <Select value={metric} onValueChange={(v) => setMetric(v as Metric)}>
@@ -169,25 +175,27 @@ export default function YearlyReport() {
                     </SelectContent>
                 </Select>
 
-                <span className="text-gray-600">
-                    {year} &middot; {totalSchoolDays} school days
+                <span className="text-sm font-bold text-slate-600">
+                    Calendar year {year}
                 </span>
 
                 <DownloadCSVButton
                     columns={csvColumns}
                     rows={csvRows}
                     fileName={`YearlyReport_${year}.csv`}
-                    className="flex items-center gap-2 ml-auto"
+                    className="sm:ml-auto"
+                    disabled={loading || rows.length === 0}
                 />
-            </div>
+            </ReportToolbar>
 
-            {error && <p className="text-red-600">{error}</p>}
+            {error && <ReportError message={error} />}
 
             <AttendanceTable<SummaryRow>
                 data={rows}
                 columns={columns}
                 loading={loading}
                 emptyMessage="No attendance recorded for this year."
+                getRowKey={(row) => row.userId}
             />
         </div>
     );


### PR DESCRIPTION
## What changed

- Reworked the report shell with clearer daily, weekly, monthly, and yearly navigation.
- Added consistent metric cards and responsive filter/export toolbars.
- Improved report terminology, spacing, and mobile behavior.
- Standardized table loading, empty, hover, and wide-content states.
- Added visible error feedback where report failures were previously only logged.
- Disabled CSV exports while loading or when no report rows are available.

## Why

The report implementations had inconsistent controls, duplicated layout, silent error handling, and cramped wide tables. This cleanup gives administrators a more predictable experience across every reporting period.

## Impact

Administrators can understand the selected report, adjust its period and metric, review high-level totals, and export results from the same visual structure on desktop or mobile.

## Validation

- `npx eslint src`
- `npx tsc --noEmit`
- `npm run build`
- Manual local layout review
