### PR TITLE
Fix admin navigation and school-year reports

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,13 +43,15 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="en">
-        <body className={nunito.variable}>
+        <body className={`${nunito.variable} min-h-screen`}>
         <Providers>
-            <Navbar />
-            <main>{children}</main>
-            <footer className="border-t border-slate-200/70 bg-white px-4 py-4 text-center text-xs font-bold tracking-wide text-slate-400">
-                Powered by <span className="text-slate-600">Clockin<span className="text-emerald-700">.Click</span></span>
-            </footer>
+            <div className="flex min-h-screen flex-col">
+                <Navbar />
+                <main className="flex-1">{children}</main>
+                <footer className="border-t border-slate-200/70 bg-white px-4 py-4 text-center text-xs font-bold tracking-wide text-slate-400">
+                    Powered by <span className="text-slate-600">Clockin<span className="text-emerald-700">.Click</span></span>
+                </footer>
+            </div>
         </Providers>
         </body>
         </html>

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -12,7 +12,7 @@ export default function LoginButton() {
             <div className="flex items-center gap-2">
                 <span className="hidden text-sm font-bold text-slate-600 lg:inline">{session.user?.name}</span>
                 <button
-                    onClick={() => signOut()}
+                    onClick={() => signOut({ callbackUrl: "/" })}
                     className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-slate-200 px-3 text-sm font-bold text-slate-700 transition hover:bg-slate-100"
                 >
                     <LogOut className="h-4 w-4" /> <span className="hidden sm:inline">Sign out</span>

--- a/src/components/YearlyReport.tsx
+++ b/src/components/YearlyReport.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { format, parseISO } from "date-fns";
+import { addMonths, endOfMonth, format, parseISO } from "date-fns";
 import AttendanceTable, { Column } from "@/components/AttendanceTable";
 import DownloadCSVButton from "@/components/DownloadCsvButton";
-import { YearPicker, selectableYears } from "@/components/PeriodPicker";
+import { MonthPicker, selectableYears } from "@/components/PeriodPicker";
 import {
     Select,
     SelectContent,
@@ -24,13 +24,24 @@ type Metric = "presence" | "hours";
 export default function YearlyReport() {
     const now = useMemo(() => new Date(), []);
     const [year, setYear] = useState(now.getFullYear());
+    const [startMonth, setStartMonth] = useState(0);
     const [metric, setMetric] = useState<Metric>("presence");
 
     const years = useMemo(() => selectableYears(now.getFullYear()), [now]);
 
+    const reportRange = useMemo(() => {
+        const firstMonth = new Date(year, startMonth, 1);
+        const lastMonth = endOfMonth(addMonths(firstMonth, 11));
+        return {
+            start: format(firstMonth, "yyyy-MM-dd"),
+            end: format(lastMonth, "yyyy-MM-dd"),
+            label: `${format(firstMonth, "MMM yyyy")} – ${format(lastMonth, "MMM yyyy")}`,
+        };
+    }, [startMonth, year]);
+
     const { summary, loading, error } = useAttendanceSummary({
-        start: `${year}-01-01`,
-        end: `${year}-12-31`,
+        start: reportRange.start,
+        end: reportRange.end,
         userTypes: REPORTED_ROLES,
         granularity: "month",
     });
@@ -158,12 +169,21 @@ export default function YearlyReport() {
     return (
         <div className="space-y-5">
             <div className="grid gap-3 sm:grid-cols-3">
-                <ReportMetric label="School days" value={totalSchoolDays} detail={String(year)} />
+                <ReportMetric label="School days" value={totalSchoolDays} detail={reportRange.label} />
                 <ReportMetric label="People recorded" value={rows.length} />
                 <ReportMetric label="Incomplete punches" value={rows.reduce((total, row) => total + row.totals.incompleteDays, 0)} tone="amber" />
             </div>
             <ReportToolbar>
-                <YearPicker year={year} years={years} onChange={setYear} />
+                <span className="text-sm font-black text-slate-700">School year starts</span>
+                <MonthPicker
+                    year={year}
+                    month={startMonth}
+                    years={years}
+                    onChange={(nextYear, nextMonth) => {
+                        setYear(nextYear);
+                        setStartMonth(nextMonth);
+                    }}
+                />
 
                 <Select value={metric} onValueChange={(v) => setMetric(v as Metric)}>
                     <SelectTrigger className="w-40">
@@ -176,13 +196,13 @@ export default function YearlyReport() {
                 </Select>
 
                 <span className="text-sm font-bold text-slate-600">
-                    Calendar year {year}
+                    12 months beginning {format(new Date(year, startMonth, 1), "MMMM yyyy")}
                 </span>
 
                 <DownloadCSVButton
                     columns={csvColumns}
                     rows={csvRows}
-                    fileName={`YearlyReport_${year}.csv`}
+                    fileName={`YearlyReport_${format(parseISO(reportRange.start), "yyyy-MM")}_to_${format(parseISO(reportRange.end), "yyyy-MM")}.csv`}
                     className="sm:ml-auto"
                     disabled={loading || rows.length === 0}
                 />


### PR DESCRIPTION
## What changed

- Redirected administrators to the kiosk homepage after signing out.
- Added a start month and year selector to yearly reports.
- Changed yearly reports to query and export an exact rolling 12-month school-year window.
- Updated the root page shell so the footer remains at the bottom on short pages.

## Why

NextAuth's default sign-out destination interrupted the kiosk flow, calendar-year-only reporting did not fit every school's academic year, and the root layout did not fill the viewport on short pages.

## Impact

Administrators return directly to the kiosk after signing out, schools can report on ranges such as August through July, and the footer now behaves consistently across pages of different heights.

## Validation

- `npx eslint src`
- `npx tsc --noEmit`
- `npm run build`
- Manual local review
