### PR TITLE
Add configurable school time zones

### DIFF
--- a/src/app/api/reports/attendance/route.tsx
+++ b/src/app/api/reports/attendance/route.tsx
@@ -3,6 +3,7 @@ import {
     queryAttendanceRange,
     batchGetUsersByIds,
     unmarshallTimeAttendance,
+    getSchoolSchedule,
 } from "@/utils/dynamo";
 import { toUtcRange } from "@/utils/attendance";
 import { requireSession } from "@/utils/apiAuth";
@@ -29,7 +30,8 @@ export async function GET(req: Request) {
             );
         }
 
-        const { start, end } = toUtcRange(startDate, endDate);
+        const { timeZone } = await getSchoolSchedule();
+        const { start, end } = toUtcRange(startDate, endDate, timeZone);
 
         // --- Parse user types (can be comma-separated) ---
         const userTypes = userTypeParam

--- a/src/app/api/reports/summary/route.ts
+++ b/src/app/api/reports/summary/route.ts
@@ -3,6 +3,7 @@ import {
     queryAttendanceRange,
     unmarshallTimeAttendance,
     getUsersByRoles,
+    getSchoolSchedule,
 } from "@/utils/dynamo";
 import {
     toUtcRange,
@@ -67,7 +68,8 @@ export async function GET(req: Request) {
             );
         }
 
-        const { start, end } = toUtcRange(startDate, endDate);
+        const { timeZone } = await getSchoolSchedule();
+        const { start, end } = toUtcRange(startDate, endDate, timeZone);
 
         const [items, users] = await Promise.all([
             queryAttendanceRange(userTypes, start, end),
@@ -78,11 +80,11 @@ export async function GET(req: Request) {
         // fall outside the requested range once resolved to the school timezone.
         const periods = enumeratePeriods(startDate, endDate, granularity);
         const records = items.map(unmarshallTimeAttendance).filter((r) => {
-            const day = localDayKey(r.dateTimeStamp);
+            const day = localDayKey(r.dateTimeStamp, timeZone);
             return day >= startDate && day <= endDate;
         });
 
-        const rows = buildSummaryRows(users, records, periods, granularity, userTypes).sort(
+        const rows = buildSummaryRows(users, records, periods, granularity, userTypes, timeZone).sort(
             (a, b) =>
                 a.lastName.localeCompare(b.lastName) || a.firstName.localeCompare(b.firstName)
         );
@@ -92,7 +94,7 @@ export async function GET(req: Request) {
             start: startDate,
             end: endDate,
             periods,
-            schoolDays: attendedDays(records),
+            schoolDays: attendedDays(records, timeZone),
             rows,
         };
 

--- a/src/app/api/settings/schedule/route.ts
+++ b/src/app/api/settings/schedule/route.ts
@@ -5,10 +5,20 @@ import type { SchoolSchedule } from "@/types/schedule";
 
 const TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 
+const isValidTimeZone = (timeZone: string) => {
+    try {
+        new Intl.DateTimeFormat("en-US", { timeZone }).format();
+        return true;
+    } catch {
+        return false;
+    }
+};
+
 const isValidSchedule = (value: unknown): value is SchoolSchedule => {
     if (!value || typeof value !== "object") return false;
     const schedule = value as SchoolSchedule;
-    return [schedule.student, schedule.staff].every((window) =>
+    return typeof schedule.timeZone === "string" && isValidTimeZone(schedule.timeZone) &&
+    [schedule.student, schedule.staff].every((window) =>
         Boolean(window) &&
         TIME_PATTERN.test(window.startTime) &&
         TIME_PATTERN.test(window.endTime) &&
@@ -36,7 +46,7 @@ export async function PUT(request: Request) {
         const schedule: unknown = await request.json();
         if (!isValidSchedule(schedule)) {
             return NextResponse.json(
-                { error: "Each start and end time must be valid, and end must be after start." },
+                { error: "Choose a valid time zone and ensure each end time is after its start time." },
                 { status: 400 }
             );
         }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <Navbar />
                 <main className="flex-1">{children}</main>
                 <footer className="border-t border-slate-200/70 bg-white px-4 py-4 text-center text-xs font-bold tracking-wide text-slate-400">
-                    Powered by <span className="text-slate-600">Clockin<span className="text-emerald-700">.Click</span></span>
+                    Powered by <a href="https://www.clockin.click" className="text-slate-600 transition hover:text-emerald-700 hover:underline">Clockin<span className="text-emerald-700">.Click</span></a>
                 </footer>
             </div>
         </Providers>

--- a/src/components/DailyReport.tsx
+++ b/src/components/DailyReport.tsx
@@ -116,7 +116,7 @@ export default function DailyReport() {
                 firstArrivalByUser.set(
                     userId,
                     new Intl.DateTimeFormat("en-CA", {
-                        timeZone: "America/Chicago",
+                        timeZone: schedule.timeZone,
                         hour: "2-digit",
                         minute: "2-digit",
                         hourCycle: "h23",
@@ -134,7 +134,7 @@ export default function DailyReport() {
             lastDepartureByUser.set(
                 record.user!.userId,
                 new Intl.DateTimeFormat("en-CA", {
-                    timeZone: "America/Chicago",
+                    timeZone: schedule.timeZone,
                     hour: "2-digit",
                     minute: "2-digit",
                     hourCycle: "h23",

--- a/src/components/ScheduleSettingsForm.tsx
+++ b/src/components/ScheduleSettingsForm.tsx
@@ -4,6 +4,16 @@ import { useEffect, useState } from "react";
 import { Clock3, Save } from "lucide-react";
 import { DEFAULT_SCHOOL_SCHEDULE, SchoolSchedule } from "@/types/schedule";
 
+const TIME_ZONES = [
+    ["America/New_York", "Eastern Time"],
+    ["America/Chicago", "Central Time"],
+    ["America/Denver", "Mountain Time"],
+    ["America/Phoenix", "Arizona Time"],
+    ["America/Los_Angeles", "Pacific Time"],
+    ["America/Anchorage", "Alaska Time"],
+    ["Pacific/Honolulu", "Hawaii Time"],
+] as const;
+
 export default function ScheduleSettingsForm() {
     const [schedule, setSchedule] = useState<SchoolSchedule>(DEFAULT_SCHOOL_SCHEDULE);
     const [loading, setLoading] = useState(true);
@@ -22,7 +32,7 @@ export default function ScheduleSettingsForm() {
             .finally(() => setLoading(false));
     }, []);
 
-    const setTime = (group: keyof SchoolSchedule, field: "startTime" | "endTime", value: string) => {
+    const setTime = (group: "student" | "staff", field: "startTime" | "endTime", value: string) => {
         setSchedule((current) => ({
             ...current,
             [group]: { ...current[group], [field]: value },
@@ -45,7 +55,7 @@ export default function ScheduleSettingsForm() {
             const body = await response.json();
             if (!response.ok) throw new Error(body.error ?? "Failed to save schedule");
             setSchedule(body);
-            setMessage("School-day schedule saved.");
+            setMessage("School settings saved.");
         } catch (reason) {
             setError(reason instanceof Error ? reason.message : "Failed to save schedule");
         } finally {
@@ -64,12 +74,19 @@ export default function ScheduleSettingsForm() {
                     </span>
                     <div>
                         <h2 className="text-xl font-black text-slate-900">Daily attendance windows</h2>
-                        <p className="text-sm text-slate-500">Times use the school timezone (America/Chicago).</p>
+                        <p className="text-sm text-slate-500">Set the local time used by attendance and reports.</p>
                     </div>
                 </div>
             </div>
 
             <div className="space-y-6 p-6">
+                <label className="block rounded-2xl border border-slate-200 p-5 text-sm font-bold text-slate-700">
+                    School time zone
+                    <select value={schedule.timeZone} onChange={(event) => setSchedule((current) => ({ ...current, timeZone: event.target.value }))} className="mt-2 h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base font-normal">
+                        {TIME_ZONES.map(([value, label]) => <option key={value} value={value}>{label} ({value})</option>)}
+                    </select>
+                    <span className="mt-2 block font-normal text-slate-500">This controls report dates, displayed punch times, and on-time calculations. Existing punches remain stored in UTC.</span>
+                </label>
                 {(["student", "staff"] as const).map((group) => (
                     <fieldset key={group} className="rounded-2xl border border-slate-200 p-5">
                         <legend className="px-2 text-sm font-black uppercase tracking-wider text-slate-600">

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -14,7 +14,7 @@ import AttendanceTable, { Column } from "@/components/AttendanceTable";
 import { cn } from "@/lib/utils";
 import DownloadCSVButton from "@/components/DownloadCsvButton";
 import {fromZonedTime, toZonedTime} from "date-fns-tz";
-import { TIME_ZONE } from "@/utils/attendance";
+import { DEFAULT_SCHOOL_SCHEDULE } from "@/types/schedule";
 import { ReportError, ReportMetric, ReportToolbar } from "@/components/ReportChrome";
 
 type BaseUser = {
@@ -47,6 +47,7 @@ export default function WeeklyReport() {
     const [users, setUsers] = useState<BaseUser[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [timeZone, setTimeZone] = useState(DEFAULT_SCHOOL_SCHEDULE.timeZone);
 
     // Memoize weekStart and weekEnd to avoid rerender loops
     const weekStart = useMemo(() => startOfWeek(selectedDate, { weekStartsOn: 0 }), [selectedDate]);
@@ -88,6 +89,15 @@ export default function WeeklyReport() {
         })();
     }, [reportedRoles]);
 
+    useEffect(() => {
+        fetch("/api/settings/schedule")
+            .then(async (response) => {
+                const data = await response.json();
+                if (response.ok && data.timeZone) setTimeZone(data.timeZone);
+            })
+            .catch((reason) => console.error("Error fetching school time zone:", reason));
+    }, []);
+
     // Fetch attendance when week changes
     useEffect(() => {
         const fetchRecords = async () => {
@@ -122,23 +132,23 @@ export default function WeeklyReport() {
         return users.map((user) => {
             const days: UserDayData[] = daysOfWeek.map((day) => {
                 // Ensure `day` is anchored to CST midnight
-                const dayCST = toZonedTime(fromZonedTime(day, TIME_ZONE), TIME_ZONE);
+                const schoolDay = toZonedTime(fromZonedTime(day, timeZone), timeZone);
 
                 const dayRecords = records.filter((r) => {
-                    const recordLocal = toZonedTime(parseISO(r.dateTimeStamp), TIME_ZONE);
-                    return r.userId === user.userId && isSameDay(recordLocal, dayCST);
+                    const recordLocal = toZonedTime(parseISO(r.dateTimeStamp), timeZone);
+                    return r.userId === user.userId && isSameDay(recordLocal, schoolDay);
                 });
 
                 const inTimes = dayRecords
                     .filter((r) => r.state.toLowerCase() === "in")
                     .map((r) =>
-                        format(toZonedTime(parseISO(r.dateTimeStamp), TIME_ZONE), "HH:mm")
+                        format(toZonedTime(parseISO(r.dateTimeStamp), timeZone), "HH:mm")
                     );
 
                 const outTimes = dayRecords
                     .filter((r) => r.state.toLowerCase() === "out")
                     .map((r) =>
-                        format(toZonedTime(parseISO(r.dateTimeStamp), TIME_ZONE), "HH:mm")
+                        format(toZonedTime(parseISO(r.dateTimeStamp), timeZone), "HH:mm")
                     );
 
                 const status =
@@ -160,7 +170,7 @@ export default function WeeklyReport() {
 
             return { user, days };
         });
-    }, [users, records, daysOfWeek]);
+    }, [users, records, daysOfWeek, timeZone]);
     // Columns
     const columns = useMemo<Column<BaseUser>[]>(() => {
         const today = new Date();

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -6,12 +6,16 @@ export type DayWindow = {
 export type SchoolSchedule = {
     student: DayWindow;
     staff: DayWindow;
+    timeZone: string;
 };
 
 export const DEFAULT_SCHOOL_SCHEDULE: SchoolSchedule = {
     student: { startTime: "08:30", endTime: "15:00" },
     staff: { startTime: "08:00", endTime: "16:00" },
+    timeZone: "America/Chicago",
 };
 
-export const scheduleGroupForUserType = (userType: string): keyof SchoolSchedule =>
+export type ScheduleGroup = "student" | "staff";
+
+export const scheduleGroupForUserType = (userType: string): ScheduleGroup =>
     userType.toLowerCase() === "learner" ? "student" : "staff";

--- a/src/utils/attendance.ts
+++ b/src/utils/attendance.ts
@@ -12,17 +12,17 @@ import type { User } from "@/types/user";
 export const TIME_ZONE = "America/Chicago";
 
 /** Local (school timezone) calendar day of an ISO instant, as yyyy-MM-dd. */
-export const localDayKey = (isoTimestamp: string): string =>
-    format(toZonedTime(parseISO(isoTimestamp), TIME_ZONE), "yyyy-MM-dd");
+export const localDayKey = (isoTimestamp: string, timeZone = TIME_ZONE): string =>
+    format(toZonedTime(parseISO(isoTimestamp), timeZone), "yyyy-MM-dd");
 
 /** Local wall-clock time of an ISO instant, as HH:mm. */
-export const localTime = (isoTimestamp: string): string =>
-    format(toZonedTime(parseISO(isoTimestamp), TIME_ZONE), "HH:mm");
+export const localTime = (isoTimestamp: string, timeZone = TIME_ZONE): string =>
+    format(toZonedTime(parseISO(isoTimestamp), timeZone), "HH:mm");
 
 /** UTC instants bounding a local-time date range, inclusive of the whole end day. */
-export const toUtcRange = (startDate: string, endDate: string) => ({
-    start: fromZonedTime(`${startDate}T00:00:00`, TIME_ZONE).toISOString(),
-    end: fromZonedTime(`${endDate}T23:59:59.999`, TIME_ZONE).toISOString(),
+export const toUtcRange = (startDate: string, endDate: string, timeZone = TIME_ZONE) => ({
+    start: fromZonedTime(`${startDate}T00:00:00`, timeZone).toISOString(),
+    end: fromZonedTime(`${endDate}T23:59:59.999`, timeZone).toISOString(),
 });
 
 /**
@@ -82,7 +82,7 @@ export const enumeratePeriods = (
  * incomplete: we never invent an end time, so totals stay defensible and the
  * bad data stays visible in the report.
  */
-export const buildDayStat = (date: string, dayRecords: TimeAttendanceRecord[]): DayStat => {
+export const buildDayStat = (date: string, dayRecords: TimeAttendanceRecord[], timeZone = TIME_ZONE): DayStat => {
     const sorted = [...dayRecords].sort((a, b) =>
         a.dateTimeStamp.localeCompare(b.dateTimeStamp)
     );
@@ -99,11 +99,11 @@ export const buildDayStat = (date: string, dayRecords: TimeAttendanceRecord[]): 
         const instant = parseISO(record.dateTimeStamp).getTime();
 
         if (state === "in") {
-            inTimes.push(localTime(record.dateTimeStamp));
+            inTimes.push(localTime(record.dateTimeStamp, timeZone));
             if (openedAt !== null) incomplete = true; // IN while already clocked in
             openedAt = instant;
         } else if (state === "out") {
-            outTimes.push(localTime(record.dateTimeStamp));
+            outTimes.push(localTime(record.dateTimeStamp, timeZone));
             if (openedAt === null) {
                 incomplete = true; // OUT with no matching IN
             } else {
@@ -127,12 +127,13 @@ export const buildDayStat = (date: string, dayRecords: TimeAttendanceRecord[]): 
 
 /** Group records by userId, then by local day, into day stats. */
 export const buildDayStatsByUser = (
-    records: TimeAttendanceRecord[]
+    records: TimeAttendanceRecord[],
+    timeZone = TIME_ZONE
 ): Map<string, Map<string, DayStat>> => {
     const byUserDay = new Map<string, Map<string, TimeAttendanceRecord[]>>();
 
     for (const record of records) {
-        const day = localDayKey(record.dateTimeStamp);
+        const day = localDayKey(record.dateTimeStamp, timeZone);
         const days = byUserDay.get(record.userId) ?? new Map();
         days.set(day, [...(days.get(day) ?? []), record]);
         byUserDay.set(record.userId, days);
@@ -142,7 +143,7 @@ export const buildDayStatsByUser = (
     for (const [userId, days] of byUserDay) {
         const userStats = new Map<string, DayStat>();
         for (const [day, dayRecords] of days) {
-            userStats.set(day, buildDayStat(day, dayRecords));
+            userStats.set(day, buildDayStat(day, dayRecords, timeZone));
         }
         stats.set(userId, userStats);
     }
@@ -155,8 +156,8 @@ export const buildDayStatsByUser = (
  * attendance rates so closures and holidays fall out on their own, with no
  * school calendar to configure.
  */
-export const attendedDays = (records: TimeAttendanceRecord[]): string[] =>
-    [...new Set(records.map((r) => localDayKey(r.dateTimeStamp)))].sort();
+export const attendedDays = (records: TimeAttendanceRecord[], timeZone = TIME_ZONE): string[] =>
+    [...new Set(records.map((r) => localDayKey(r.dateTimeStamp, timeZone)))].sort();
 
 const punchDetail = (stat: DayStat): string => {
     const times = [
@@ -193,9 +194,10 @@ export const buildSummaryRows = (
     records: TimeAttendanceRecord[],
     periods: string[],
     granularity: Granularity,
-    requestedRoles: string[]
+    requestedRoles: string[],
+    timeZone = TIME_ZONE
 ): SummaryRow[] => {
-    const statsByUser = buildDayStatsByUser(records);
+    const statsByUser = buildDayStatsByUser(records, timeZone);
 
     return users.map((user) => {
         const dayStats = statsByUser.get(user.userId) ?? new Map<string, DayStat>();

--- a/src/utils/demoData.ts
+++ b/src/utils/demoData.ts
@@ -87,6 +87,7 @@ export const resetDemoData = async () => {
     await putSchoolSchedule({
         student: { startTime: "08:30", endTime: "15:00" },
         staff: { startTime: "08:00", endTime: "16:00" },
+        timeZone: "America/Chicago",
     });
 
     const punches = demoDays().flatMap((day, index) => [

--- a/src/utils/dynamo.ts
+++ b/src/utils/dynamo.ts
@@ -593,6 +593,7 @@ export const getSchoolSchedule = async (): Promise<SchoolSchedule> => {
             startTime: getString(result.Item.StaffStartTime) ?? DEFAULT_SCHOOL_SCHEDULE.staff.startTime,
             endTime: getString(result.Item.StaffEndTime) ?? DEFAULT_SCHOOL_SCHEDULE.staff.endTime,
         },
+        timeZone: getString(result.Item.TimeZone) ?? DEFAULT_SCHOOL_SCHEDULE.timeZone,
     };
 };
 
@@ -605,6 +606,7 @@ export const putSchoolSchedule = async (schedule: SchoolSchedule): Promise<void>
             StudentEndTime: { S: schedule.student.endTime },
             StaffStartTime: { S: schedule.staff.startTime },
             StaffEndTime: { S: schedule.staff.endTime },
+            TimeZone: { S: schedule.timeZone },
             UpdatedAt: { S: new Date().toISOString() },
         },
     }));


### PR DESCRIPTION
## What changed

- Added a school time-zone selector to the Settings page.
- Persisted the selected IANA time zone in the existing school Settings record.
- Applied the configured zone to report query boundaries, local-day grouping, punch displays, and attendance schedule calculations.
- Retained `America/Chicago` as the fallback for existing schools and demo data.
- Linked the footer Clockin.Click branding to the marketing website.

## Why

Attendance timestamps are stored in UTC, but report boundaries and displayed times were hardcoded to Central Time. Schools in other regions need those calculations to follow their own local calendar and daylight-saving rules.

## Impact

Administrators can choose their school's time zone without migrating attendance data. Daily, weekly, monthly, and yearly reports will interpret existing and future punches consistently in that zone.

## Validation

- `npx eslint src`
- `npx tsc --noEmit`
- `npm run build`
- Manual local review
