### PR TITLE
Add API authorization tests

### DIFF
--- a/src/app/api/demo/reset/route.test.ts
+++ b/src/app/api/demo/reset/route.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { resetDemoData } = vi.hoisted(() => ({ resetDemoData: vi.fn() }));
+vi.mock("@/utils/demoData", () => ({ resetDemoData }));
+import { POST } from "./route";
+
+const originalDemoMode = process.env.DEMO_MODE;
+const originalToken = process.env.DEMO_RESET_TOKEN;
+const request = (token?: string) => new Request("http://localhost/api/demo/reset", {
+  method: "POST", headers: token ? { authorization: `Bearer ${token}` } : {},
+});
+
+describe("demo reset API", () => {
+  beforeEach(() => { vi.clearAllMocks(); process.env.DEMO_MODE = "true"; process.env.DEMO_RESET_TOKEN = "secret"; });
+  afterEach(() => { process.env.DEMO_MODE = originalDemoMode; process.env.DEMO_RESET_TOKEN = originalToken; });
+
+  it("is hidden outside demo mode", async () => {
+    process.env.DEMO_MODE = "false";
+    expect((await POST(request())).status).toBe(404);
+  });
+
+  it("requires a configured matching bearer token", async () => {
+    expect((await POST(request())).status).toBe(401);
+    expect((await POST(request("wrong"))).status).toBe(401);
+    delete process.env.DEMO_RESET_TOKEN;
+    expect((await POST(request("secret"))).status).toBe(401);
+  });
+
+  it("resets demo data for an authorized request", async () => {
+    resetDemoData.mockResolvedValue({ reset: true });
+    const response = await POST(request("secret"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ reset: true });
+  });
+
+  it("returns 500 when reset fails", async () => {
+    resetDemoData.mockRejectedValue(new Error("failed"));
+    expect((await POST(request("secret"))).status).toBe(500);
+  });
+});

--- a/src/app/api/settings/schedule/route.test.ts
+++ b/src/app/api/settings/schedule/route.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const mocks = vi.hoisted(() => ({ requireAdminApi: vi.fn(), getSchoolSchedule: vi.fn(), putSchoolSchedule: vi.fn() }));
+vi.mock("@/utils/apiAuth", () => ({ requireAdminApi: mocks.requireAdminApi }));
+vi.mock("@/utils/dynamo", () => ({ getSchoolSchedule: mocks.getSchoolSchedule, putSchoolSchedule: mocks.putSchoolSchedule }));
+import { GET, PUT } from "./route";
+
+const schedule = {
+  student: { startTime: "08:30", endTime: "15:00" },
+  staff: { startTime: "08:00", endTime: "16:00" },
+  timeZone: "America/Chicago",
+};
+
+describe("schedule settings API", () => {
+  beforeEach(() => { vi.clearAllMocks(); mocks.requireAdminApi.mockResolvedValue(null); });
+
+  it("enforces read and edit authorization", async () => {
+    mocks.requireAdminApi.mockResolvedValue(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+    expect((await GET()).status).toBe(401);
+    expect((await PUT(new Request("http://localhost", { method: "PUT", body: "{}" }))).status).toBe(401);
+  });
+
+  it("loads and saves a valid schedule", async () => {
+    mocks.getSchoolSchedule.mockResolvedValue(schedule);
+    expect(await (await GET()).json()).toEqual(schedule);
+    const response = await PUT(new Request("http://localhost", { method: "PUT", body: JSON.stringify(schedule) }));
+    expect(response.status).toBe(200);
+    expect(mocks.putSchoolSchedule).toHaveBeenCalledWith(schedule);
+  });
+
+  it.each([
+    null,
+    { ...schedule, timeZone: "Mars/Olympus" },
+    { ...schedule, student: null },
+    { ...schedule, student: { startTime: "8:30", endTime: "15:00" } },
+    { ...schedule, staff: { startTime: "17:00", endTime: "16:00" } },
+  ])("rejects invalid schedules", async (value) => {
+    expect((await PUT(new Request("http://localhost", { method: "PUT", body: JSON.stringify(value) }))).status).toBe(400);
+  });
+
+  it("handles read, write, and malformed JSON failures", async () => {
+    mocks.getSchoolSchedule.mockRejectedValueOnce(new Error("read"));
+    expect((await GET()).status).toBe(500);
+    mocks.putSchoolSchedule.mockRejectedValueOnce(new Error("write"));
+    expect((await PUT(new Request("http://localhost", { method: "PUT", body: JSON.stringify(schedule) }))).status).toBe(500);
+    expect((await PUT(new Request("http://localhost", { method: "PUT", body: "{" }))).status).toBe(500);
+  });
+});

--- a/src/app/api/users/[id]/status/route.local.test.ts
+++ b/src/app/api/users/[id]/status/route.local.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({ isAllowedMockClock: vi.fn() }));
+vi.mock("@/utils/dynamo", () => ({
+  getUserById: vi.fn(), getUserByPin: vi.fn(), updateUserStatus: vi.fn(), logTimeClock: vi.fn(),
+}));
+vi.mock("@/utils/kioskMock", () => ({
+  isLocalKioskMockEnabled: true,
+  isAllowedMockClock: mocks.isAllowedMockClock,
+}));
+
+import { PATCH } from "./route";
+
+const call = () => PATCH(new NextRequest("http://localhost/api/users/mock-staff/status", {
+  method: "PATCH",
+  body: JSON.stringify({ status: "In", pin: "1357" }),
+  headers: { "content-type": "application/json" },
+}), { params: Promise.resolve({ id: "mock-staff" }) });
+
+describe("local kiosk status API", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns a mock result for an allowed clock action", async () => {
+    mocks.isAllowedMockClock.mockReturnValue(true);
+    const response = await call();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ userId: "mock-staff", status: "In", mocked: true });
+  });
+
+  it("forbids an unrelated local clock action", async () => {
+    mocks.isAllowedMockClock.mockReturnValue(false);
+    expect((await call()).status).toBe(403);
+  });
+});

--- a/src/app/api/users/[id]/status/route.test.ts
+++ b/src/app/api/users/[id]/status/route.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  getUserById: vi.fn(), getUserByPin: vi.fn(), updateUserStatus: vi.fn(), logTimeClock: vi.fn(),
+  isAllowedMockClock: vi.fn(),
+}));
+vi.mock("@/utils/dynamo", () => ({
+  getUserById: mocks.getUserById, getUserByPin: mocks.getUserByPin,
+  updateUserStatus: mocks.updateUserStatus, logTimeClock: mocks.logTimeClock,
+}));
+vi.mock("@/utils/kioskMock", () => ({ isLocalKioskMockEnabled: false, isAllowedMockClock: mocks.isAllowedMockClock }));
+
+import { PATCH } from "./route";
+
+const call = (body: unknown, id = "target") => PATCH(new NextRequest(`http://localhost/api/users/${id}/status`, {
+  method: "PATCH", body: JSON.stringify(body), headers: { "content-type": "application/json" },
+}), { params: Promise.resolve({ id }) });
+const user = (overrides: Record<string, unknown> = {}) => ({
+  userId: "actor", firstName: "A", lastName: "User", pin: "1234", roles: ["staff"], archived: false, ...overrides,
+});
+
+describe("kiosk status API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateUserStatus.mockResolvedValue({ userId: "target", status: "In" });
+  });
+
+  it("validates status and PIN", async () => {
+    expect((await call({ status: "Away", pin: "1234" })).status).toBe(400);
+    expect((await call({ status: "In", pin: "12" })).status).toBe(401);
+    expect((await call({ status: "In", pin: 1234 })).status).toBe(401);
+  });
+
+  it("rejects missing and archived actors or targets", async () => {
+    mocks.getUserByPin.mockResolvedValue(null);
+    mocks.getUserById.mockResolvedValue(user({ userId: "target" }));
+    expect((await call({ status: "In", pin: "1234" })).status).toBe(401);
+    mocks.getUserByPin.mockResolvedValue(user({ archived: true }));
+    expect((await call({ status: "In", pin: "1234" })).status).toBe(401);
+  });
+
+  it("allows staff and volunteers to clock themselves", async () => {
+    const actor = user();
+    mocks.getUserByPin.mockResolvedValue(actor);
+    mocks.getUserById.mockResolvedValue(actor);
+    const response = await call({ status: "In", pin: "1234" }, "actor");
+    expect(response.status).toBe(200);
+    expect(mocks.logTimeClock).toHaveBeenCalledWith("actor", "staff", "In", "actor");
+  });
+
+  it("allows guardians to clock linked learners", async () => {
+    mocks.getUserByPin.mockResolvedValue(user({ roles: ["guardian"], learners: [{ userId: "target" }] }));
+    mocks.getUserById.mockResolvedValue(user({ userId: "target", roles: ["learner"] }));
+    expect((await call({ status: "Out", pin: "1234" })).status).toBe(200);
+    expect(mocks.logTimeClock).toHaveBeenCalledWith("target", "learner", "Out", "actor");
+  });
+
+  it("forbids unrelated clock actions", async () => {
+    mocks.getUserByPin.mockResolvedValue(user());
+    mocks.getUserById.mockResolvedValue(user({ userId: "target" }));
+    expect((await call({ status: "In", pin: "1234" })).status).toBe(403);
+  });
+
+  it("rejects target roles that cannot use the clock", async () => {
+    const actor = user({ userId: "target", roles: ["administrator"] });
+    mocks.getUserByPin.mockResolvedValue(actor);
+    mocks.getUserById.mockResolvedValue(actor);
+    expect((await call({ status: "In", pin: "1234" })).status).toBe(403);
+
+    const guardian = user({ roles: ["guardian"], learners: [{ userId: "target" }] });
+    mocks.getUserByPin.mockResolvedValue(guardian);
+    mocks.getUserById.mockResolvedValue(user({ userId: "target", roles: ["guardian"] }));
+    expect((await call({ status: "In", pin: "1234" })).status).toBe(400);
+  });
+
+  it("returns 500 without partially hiding persistence failures", async () => {
+    const actor = user();
+    mocks.getUserByPin.mockResolvedValue(actor);
+    mocks.getUserById.mockResolvedValue(actor);
+    mocks.updateUserStatus.mockRejectedValue(new Error("write failed"));
+    expect((await call({ status: "In", pin: "1234" }, "actor")).status).toBe(500);
+  });
+});

--- a/src/app/api/users/route.test.ts
+++ b/src/app/api/users/route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  requireAdminApi: vi.fn(), getAllUsers: vi.fn(), getUsersByRoles: vi.fn(), getUserByEmail: vi.fn(),
+  getUserByPin: vi.fn(), putUser: vi.fn(), getLocalPeople: vi.fn(), getLocalPersonByEmail: vi.fn(),
+  getLocalPersonByPin: vi.fn(), putLocalPerson: vi.fn(),
+}));
+vi.mock("@/utils/apiAuth", () => ({ requireAdminApi: mocks.requireAdminApi }));
+vi.mock("@/utils/dynamo", () => ({
+  getAllUsers: mocks.getAllUsers, getUsersByRoles: mocks.getUsersByRoles,
+  getUserByEmail: mocks.getUserByEmail, getUserByPin: mocks.getUserByPin, putUser: mocks.putUser,
+}));
+vi.mock("@/utils/localPeopleMock", () => ({
+  isLocalPeopleMockEnabled: false, getLocalPeople: mocks.getLocalPeople,
+  getLocalPersonByEmail: mocks.getLocalPersonByEmail, getLocalPersonByPin: mocks.getLocalPersonByPin,
+  putLocalPerson: mocks.putLocalPerson,
+}));
+
+import { GET, POST } from "./route";
+
+const person = { userId: "u1", firstName: "Maya", lastName: "Rivera", pin: "1234", roles: ["learner"] };
+const request = (url = "http://localhost/api/users", body?: unknown) => new NextRequest(url, body === undefined ? undefined : {
+  method: "POST", body: JSON.stringify(body), headers: { "content-type": "application/json" },
+});
+
+describe("users collection API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAdminApi.mockResolvedValue(null);
+    mocks.getUserByPin.mockResolvedValue(null);
+    mocks.getUserByEmail.mockResolvedValue(null);
+  });
+
+  it("returns the authorization response without reading users", async () => {
+    mocks.requireAdminApi.mockResolvedValue(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+    expect((await GET(request())).status).toBe(401);
+    expect(mocks.getAllUsers).not.toHaveBeenCalled();
+  });
+
+  it("lists all users without exposing PINs", async () => {
+    mocks.getAllUsers.mockResolvedValue([person]);
+    const response = await GET(request());
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([{ ...person, pin: "" }]);
+  });
+
+  it("normalizes role filters", async () => {
+    mocks.getUsersByRoles.mockResolvedValue([person]);
+    await GET(request("http://localhost/api/users?roles=Learner,%20STAFF"));
+    expect(mocks.getUsersByRoles).toHaveBeenCalledWith(["learner", "staff"]);
+  });
+
+  it("returns 500 when listing fails", async () => {
+    mocks.getAllUsers.mockRejectedValue(new Error("AWS unavailable"));
+    const response = await GET(request());
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to fetch users" });
+  });
+
+  it("requires edit access and required fields", async () => {
+    mocks.requireAdminApi.mockResolvedValueOnce(NextResponse.json({ error: "Forbidden" }, { status: 403 }));
+    expect((await POST(request(undefined, person))).status).toBe(403);
+    for (const field of ["userId", "firstName", "lastName", "roles"] as const) {
+      const invalid = { ...person, [field]: field === "roles" ? [] : "" };
+      expect((await POST(request(undefined, invalid))).status).toBe(400);
+    }
+  });
+
+  it("returns validation errors", async () => {
+    const response = await POST(request(undefined, { ...person, pin: "12" }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe("PIN must be exactly four digits.");
+  });
+
+  it("rejects duplicate PINs and email addresses", async () => {
+    mocks.getUserByPin.mockResolvedValueOnce(person);
+    expect((await POST(request(undefined, person))).status).toBe(409);
+    mocks.getUserByEmail.mockResolvedValueOnce(person);
+    expect((await POST(request(undefined, { ...person, pin: "5678", email: "maya@example.com" }))).status).toBe(409);
+  });
+
+  it("creates a normalized guardian without returning its PIN", async () => {
+    const body = { ...person, roles: [" Guardian "], firstName: " Maya ", pin: "5678", learners: [person] };
+    const response = await POST(request(undefined, body));
+    expect(response.status).toBe(200);
+    expect(mocks.putUser).toHaveBeenCalledWith(expect.objectContaining({ firstName: "Maya", roles: ["guardian"], learners: [person] }));
+    expect((await response.json()).user.pin).toBe("");
+  });
+
+  it("returns 500 when creation fails", async () => {
+    mocks.putUser.mockRejectedValue(new Error("write failed"));
+    expect((await POST(request(undefined, person))).status).toBe(500);
+  });
+});

--- a/src/utils/apiAuth.test.ts
+++ b/src/utils/apiAuth.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getServerSession } = vi.hoisted(() => ({ getServerSession: vi.fn() }));
+vi.mock("next-auth/next", () => ({ getServerSession }));
+vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
+
+import { requireAdminApi, requireSession } from "./apiAuth";
+
+describe("API authorization guards", () => {
+  beforeEach(() => getServerSession.mockReset());
+
+  it("requires a signed-in user for protected reports", async () => {
+    getServerSession.mockResolvedValue(null);
+    const response = await requireSession();
+    expect(response?.status).toBe(401);
+    expect(await response?.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("allows a signed-in report user", async () => {
+    getServerSession.mockResolvedValue({ user: { email: "admin@example.com" } });
+    expect(await requireSession()).toBeNull();
+  });
+
+  it("rejects non-admin users", async () => {
+    getServerSession.mockResolvedValue({ user: { isAdmin: false } });
+    expect((await requireAdminApi())?.status).toBe(401);
+  });
+
+  it("allows read-only admins to read but not edit", async () => {
+    getServerSession.mockResolvedValue({ user: { isAdmin: true, adminLevel: "read-only" } });
+    expect(await requireAdminApi("read")).toBeNull();
+    expect((await requireAdminApi("edit"))?.status).toBe(403);
+  });
+
+  it("allows edit-level administrators", async () => {
+    getServerSession.mockResolvedValue({ user: { isAdmin: true, adminLevel: "edit" } });
+    expect(await requireAdminApi("edit")).toBeNull();
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,8 +13,13 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json-summary"],
       include: [
+        "src/app/api/demo/reset/route.ts",
+        "src/app/api/settings/schedule/route.ts",
+        "src/app/api/users/route.ts",
+        "src/app/api/users/[id]/status/route.ts",
         "src/types/schedule.ts",
         "src/types/user.ts",
+        "src/utils/apiAuth.ts",
         "src/utils/attendance.ts",
         "src/utils/formatters.ts",
         "src/utils/kioskMock.ts",


### PR DESCRIPTION
Adds deterministic authorization and behavior tests around the main app's highest-risk API boundaries. The suite verifies session and admin access levels, user listing and creation, duplicate PIN and email conflicts, kiosk clock permissions, guardian-to-learner clocking, local kiosk behavior, schedule validation, demo reset authentication, and service failure responses. The covered API routes are now included in the existing 90% global coverage gate. Validation completed with 58 passing tests, 99.34% statement coverage, 90.49% branch coverage, 97.1% function coverage, 99.63% line coverage, a clean ESLint run, and a successful production build.