### PR TITLE
Add kiosk browser tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,5 @@ jobs:
       - run: npm run lint
       - run: npm run test:coverage
       - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Use `npm run test:watch` while developing, or `npm run test:coverage` to generat
 the coverage report. CI enforces a minimum of 90% for statements, branches,
 functions, and lines across the covered application modules.
 
+Browser-level kiosk tests run with Playwright and the local kiosk mock:
+
+```bash
+npx playwright install chromium
+npm run test:e2e
+```
+
+Use `npm run test:e2e:ui` for Playwright's interactive test runner.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/e2e/kiosk.spec.ts
+++ b/e2e/kiosk.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+test("valid staff PIN can clock in and sees confirmation", async ({ page }) => {
+  await page.getByLabel("Four-digit PIN").fill("1357");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(page.getByRole("heading", { name: "Alex Morgan" })).toBeVisible();
+  await expect(page.getByText("Your current status")).toContainText("Out");
+
+  const clockIn = page.getByRole("button", { name: "Clock in" });
+  await clockIn.click();
+  await expect(clockIn).toHaveAttribute("aria-pressed", "true");
+  await page.getByRole("button", { name: "Confirm 1 change" }).click();
+
+  await expect(page.getByRole("status")).toHaveText("Attendance updated successfully.");
+  await expect(page.getByRole("heading", { name: "Enter your PIN" })).toBeVisible();
+});
+
+test("guardian PIN displays linked learners and clocks multiple people", async ({ page }) => {
+  await page.getByLabel("Four-digit PIN").fill("2468");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(page.getByRole("heading", { name: "Jordan Rivera" })).toBeVisible();
+  await expect(page.getByText("Maya Rivera")).toBeVisible();
+  await expect(page.getByText("Theo Rivera")).toBeVisible();
+
+  const mayaRow = page.getByText("Maya Rivera").locator("..").locator("..");
+  const theoRow = page.getByText("Theo Rivera").locator("..").locator("..");
+  await mayaRow.getByRole("button", { name: "Clock in" }).click();
+  await theoRow.getByRole("button", { name: "Clock out" }).click();
+  await page.getByRole("button", { name: "Confirm 2 changes" }).click();
+
+  await expect(page.getByRole("status")).toHaveText("Attendance for 2 people updated successfully.");
+});
+
+test("incomplete PINs are blocked and invalid PINs show an actionable error", async ({ page }) => {
+  const input = page.getByLabel("Four-digit PIN");
+  await input.fill("12");
+  await expect(page.getByRole("button", { name: "Continue" })).toBeDisabled();
+
+  await input.fill("0000");
+  await page.getByRole("button", { name: "Continue" }).click();
+  await expect(page.getByRole("status")).toHaveText("Try demo PIN 2468 or 1357");
+});
+
+test("keypad supports correction and starting over", async ({ page }) => {
+  for (const digit of [1, 3, 5, 8]) await page.getByRole("button", { name: String(digit), exact: true }).click();
+  await page.getByRole("button", { name: "Delete last digit" }).click();
+  await page.getByRole("button", { name: "7", exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+  await expect(page.getByRole("heading", { name: "Alex Morgan" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Use a different PIN" }).click();
+  await expect(page.getByLabel("Four-digit PIN")).toHaveValue("");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
@@ -1890,6 +1891,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8180,6 +8197,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.888.0",
@@ -37,6 +39,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+  webServer: {
+    command: "npm run dev -- --hostname 127.0.0.1",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      LOCAL_KIOSK_MOCK: "true",
+      NEXT_PUBLIC_DEMO_MODE: "true",
+      NEXT_PUBLIC_SCHOOL_NAME: "Clockin.Click Demo School",
+    },
+  },
+});


### PR DESCRIPTION
Adds Playwright browser testing for the main kiosk journey using the existing local kiosk mock, without requiring AWS access. The suite verifies staff PIN lookup and clock-in, guardian access to linked learners, multiple attendance changes, incomplete and invalid PIN handling, keypad correction, starting over, and visible success confirmation. CI now installs Chromium and runs the browser suite alongside linting, unit/API coverage, and the production build. Validation completed with four passing Playwright journeys, 58 passing unit and API tests, coverage above 90%, a clean ESLint run, and a successful production build.