### PR TITLE
Add production kiosk smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,36 @@
+name: Smoke test deployed schools
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: school-production-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Wait for Amplify and verify school kiosks
+        env:
+          SMOKE_TEST_URLS: ${{ vars.SMOKE_TEST_URLS || 'https://demo.clockin.click,https://wildflower.clockin.click' }}
+          SMOKE_TEST_ATTEMPTS: "30"
+          SMOKE_TEST_DELAY_MS: "20000"
+        run: npm run test:smoke

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ npm run test:e2e
 
 Use `npm run test:e2e:ui` for Playwright's interactive test runner.
 
+Production smoke checks run after the main test workflow succeeds, every six
+hours, and on demand. They verify that each public kiosk remains available over
+HTTPS without being redirected to administrator authentication. Set the
+`SMOKE_TEST_URLS` repository variable to a comma-separated list to override the
+default demo and Wildflower sites.
+
+Run the same checks locally with:
+
+```bash
+SMOKE_TEST_URLS=https://demo.clockin.click npm run test:smoke
+```
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "test:smoke": "node scripts/smoke-test.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.888.0",

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,85 @@
+const urls = (process.env.SMOKE_TEST_URLS || "https://demo.clockin.click,https://wildflower.clockin.click")
+  .split(/[\s,]+/)
+  .map((value) => value.trim().replace(/\/$/, ""))
+  .filter(Boolean);
+
+const attempts = Number.parseInt(process.env.SMOKE_TEST_ATTEMPTS || "1", 10);
+const delayMs = Number.parseInt(process.env.SMOKE_TEST_DELAY_MS || "20000", 10);
+
+const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function fetchPage(url) {
+  const response = await fetch(url, {
+    redirect: "follow",
+    headers: { "user-agent": "ClockinClick-SmokeTest/1.0" },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`);
+  if (!response.url.startsWith("https://")) {
+    throw new Error(`${url} did not finish on HTTPS (${response.url})`);
+  }
+  if (new URL(response.url).pathname.startsWith("/api/auth/signin")) {
+    throw new Error(`${url} redirected the public kiosk to authentication`);
+  }
+
+  return response.text();
+}
+
+async function checkValidationEndpoint(baseUrl) {
+  const url = `${baseUrl}/api/users/by-pin`;
+  const response = await fetch(url, {
+    redirect: "manual",
+    headers: { "user-agent": "ClockinClick-SmokeTest/1.0" },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (response.status !== 400) {
+    throw new Error(`${url} returned HTTP ${response.status}; expected 400`);
+  }
+  if (!response.url.startsWith("https://")) {
+    throw new Error(`${url} was not served over HTTPS`);
+  }
+
+  const body = await response.json();
+  if (body.error !== "Pin is required") {
+    throw new Error(`${url} did not return the expected validation response`);
+  }
+}
+
+async function checkSite(baseUrl) {
+  const body = await fetchPage(baseUrl);
+  if (!/Enter your PIN/i.test(body) || !/Clockin\.Click/i.test(body)) {
+    throw new Error(`${baseUrl} did not contain the expected kiosk content`);
+  }
+
+  await checkValidationEndpoint(baseUrl);
+}
+
+if (urls.length === 0) throw new Error("SMOKE_TEST_URLS did not contain any URLs");
+if (!Number.isInteger(attempts) || attempts < 1) {
+  throw new Error("SMOKE_TEST_ATTEMPTS must be a positive integer");
+}
+if (!Number.isInteger(delayMs) || delayMs < 0) {
+  throw new Error("SMOKE_TEST_DELAY_MS must be a non-negative integer");
+}
+
+let lastError;
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  try {
+    for (const url of urls) {
+      await checkSite(url);
+      console.log(`PASS ${url} kiosk smoke checks passed`);
+    }
+    process.exit(0);
+  } catch (error) {
+    lastError = error;
+    console.error(
+      `Smoke attempt ${attempt}/${attempts} failed:`,
+      error instanceof Error ? error.message : error,
+    );
+    if (attempt < attempts) await wait(delayMs);
+  }
+}
+
+throw lastError;


### PR DESCRIPTION
## What changed

- add dependency-free production smoke checks for the demo and Wildflower kiosks
- verify HTTPS, public kiosk access, expected branding, and the safe PIN validation response
- run checks after successful main CI, every six hours, and manually with Amplify deployment retries
- document local execution and the optional `SMOKE_TEST_URLS` repository variable

## Why

This catches deployment, domain, authentication-loop, and API availability regressions shortly after they reach production without changing school data.

## Validation

- live smoke checks passed for `demo.clockin.click` and `wildflower.clockin.click`
- `npm run lint`
- `npm run test:coverage` — 58 tests passed; all thresholds remain above 90%
- `npm run build`
